### PR TITLE
Copy upgrades and Docs Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Our <a target="_blank" href="{{ links.website.pfd_desktop_install }}">Flagship D
 Choose a topic from the list below to get started with Pieces:
 
 * [Save a Snippet](https://docs.page/pieces-app/documentation/product-highlights-and-benefits/saving-useful-developer-materials)
-* [Share a Snippet](https://docs.page/pieces-app/documentation/personalized-link-sharing/single-click-link-sharing)
+* [Share a Snippet](https://docs.page/pieces-app/documentation/personalized-link-sharing/one-click-snippet-sharing)
 * [Import Snippets from GitHub](https://docs.page/pieces-app/documentation/product-highlights-and-benefits/import-gists-from-github)
 * [Local Snippet Discovery](https://docs.page/pieces-app/documentation/product-highlights-and-benefits/in-project-snippet-discovery)
 * [FAQs](https://docs.page/pieces-app/documentation/faq)

--- a/docs.json
+++ b/docs.json
@@ -155,10 +155,10 @@
           "smart_warnings": "https://docs.pieces.apps/features/auto-enrichment#smart-warnings"
         },
         "global_search_suggestion_reuse": {
-          "global_search": "https://docs.pieces.app/global-search-suggestion-reuse/global_search",
-          "search_settings": "https://docs.pieces.app/global-search-suggestion-reuse/adjusting-settings-for-search",
-          "sort_scope_relevant": "https://docs.pieces.app/global-search-suggestion-reuse/sort-scope-relevant",
-          "workflow_activity_stream": "https://docs.pieces.app/global-search-suggestion-reuse/workflow-activity"
+          "global_search": "https://docs.pieces.app/features/global_search",
+          "search_settings": "https://docs.pieces.app/features/global-search#adjusting-settings-for-optimal-search-results",
+          "sort_scope_relevant": "https://docs.pieces.app/features/global-search#sorting-by-realtime-or-scope-relevant-suggestions",
+          "workflow_activity_stream": "https://docs.pieces.app/features/workflow-activity"
         },
         "personalized_link_sharing": {
           "single_click_link_sharing": "https://docs.pieces.app/features/one-click-link-sharing",

--- a/docs.json
+++ b/docs.json
@@ -52,21 +52,21 @@
     ]],
     ["Product Highlights & Benefits", [
       ["Save Developer Materials", "/product-highlights-and-benefits/saving-useful-developer-materials"],
-      ["Saving Screenshots & OCR", "/product-highlights-and-benefits/saving-screenshots"],
-      ["In-Project Snippet Discovery", "/product-highlights-and-benefits/in-project-snippet-discovery"],
+      ["Save Screenshots & Extract Code", "/product-highlights-and-benefits/saving-screenshots"],
       ["Import Gists from GitHub", "/product-highlights-and-benefits/import-gists-from-github"],
+      ["In-Project Snippet Discovery", "/product-highlights-and-benefits/in-project-snippet-discovery"],
       ["Privacy & Security", "/product-highlights-and-benefits/privacy-security-data"]
     ]
     ],
     ["Product Features", [
       ["Auto Enrichment", "/features/auto-enrichment"],
-      ["Single Click Sharing", "/features/one-click-snippet-sharing"],
+      ["Code Completion", "/features/code-completion"],
+      ["Code Generation", "/features/creation-and-generation"],
       ["Global Search", "/features/global-search"],
-      ["Workflow Activity", "/features/workflow-activity"],
-      ["Manage Saved Materials", "/features/managing-saved-materials"],
-      ["Creation & Generation", "/features/creation-and-generation"],
-      ["Transforming Snippets", "/features/transforming-snippets"],
-      ["Code Completion", "/features/code-completion"]
+      ["Material Storage & Management", "/features/managing-saved-materials"],
+      ["One Click Sharing", "/features/one-click-snippet-sharing"],
+      ["Snippet Transformations", "/features/transforming-snippets"],
+      ["Workflow Activity", "/features/workflow-activity"]
     ]],
     ["Use Cases", [
       ["Reduce Endless Google Searching", "/use-cases/countless-google-searches"],

--- a/docs.json
+++ b/docs.json
@@ -61,7 +61,7 @@
     ["Product Features", [
       ["Auto Enrichment", "/features/auto-enrichment"],
       ["Code Completion", "/features/code-completion"],
-      ["Code Generation", "/features/creation-and-generation"],
+      ["Creating & Generating Code", "/features/creation-and-generation"],
       ["Global Search", "/features/global-search"],
       ["Material Storage & Management", "/features/managing-saved-materials"],
       ["One Click Sharing", "/features/one-click-snippet-sharing"],

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -8,7 +8,9 @@ description: Learn how Pieces for Developers uses ML and AI with ChatGPT to enri
 # Auto-Enrichment
 Pieces for Developers enriches your content as you save snippets and makes it easy to get back to where you originally saved your code.
 
-## How to View Metadata & Enrichment Details
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
+
+## How to View Metadata & Enrichment Details ` cmd + i ` | ` ctrl + i `
 All background processing that goes into Pieces gives you the ability to access more data around your resources and code snippets. You can view the information by:
 - Press ```cmd + i``` or ```ctrl + i``` to access the Context View
 - [In List View] pressing the _view all context_ button on the top right of the context preview
@@ -22,24 +24,24 @@ Once you enter the Context view, you will see data added both [automatically via
 
 Whether you are in List or Gallery View, you will have access to the same set of sections.
 
-### Description `cmd + shift + n` or `ctrl + shift + n`
-You can press the entire _description_ box to open the "Edit Description Drawer" or use the `cmd/ctrl + shift + n` shortcut to edit the contents of the description context field.
+### Description: ` cmd + shift + n ` | ` ctrl + shift + n `
+You can press the entire _description_ box to open the "Edit Description Drawer" or use the ` cmd/ctrl + shift + n ` shortcut to edit the contents of the description context field.
 
 This section will by default be filled out, and you can reference the following example:
 
-``` text
-📝 Custom Description:
-Write a custom description here.
+```text
+  📝 Custom Description:
+  Write a custom description here.
 
-💡 Smart Description:
-The article explains how to use the Snipping Tool feature in Windows to capture screenshots.
+  💡 Smart Description:
+  The article explains how to use the Snipping Tool feature in Windows to capture screenshots.
 
-🔎 Suggested Searches:
-Windows screenshot tool
-How to capture screenshots on Windows
-Microsoft support screenshot guide
-Windows snipping tool tutorial
-Windows screenshot shortcut
+  🔎 Suggested Searches:
+  Windows screenshot tool
+  How to capture screenshots on Windows
+  Microsoft support screenshot guide
+  Windows snipping tool tutorial
+  Windows screenshot shortcut
 ```
 
 A few things to note about this format:
@@ -49,11 +51,11 @@ A few things to note about this format:
     - We auto generate this description and is used for search-ability, reading through your list of snippets, and is a description of what the snippet does.
         - [you can use this feature to identify what a code snippet can do when you aren't sure](#)
 **Suggested Searches**
-    - These are great search terms that you can use to find snippets that are similar to the resource they are attached to. These are good examples that you can compare to the examples found on the [Global Search Page]() and try them in the app.
+    - These are great search terms that you can use to find snippets that are similar to the resource they are attached to. These are good examples that you can compare to the examples found on the [Global Search Page](#) and try them in the app.
 
 ---
 
-### Tags `cmd + t` or `ctrl + t`
+### Tags: `cmd + t` | `ctrl + t`
 Open the Tags drawer by clicking anywhere overtop of the tags section, or by pressing the ` cmd/ctrl + t ` shortcut. This will bring pull up a list of tags that have already been [added when you saved the resource](#), along with suggested snippets that you can click to quickly add to the snippet.
 
 To create a custom tag, you can start typing once the drawer opens and add any tag you like directly into the preexisting tags list.
@@ -81,7 +83,7 @@ To remove a tag:
 
 ---
 
-### Related Links `cmd + k` or `ctrl + k`
+### Related Links: `cmd + k` | `ctrl + k`
 Related links can be opened by clicking on the _background_ of the related links section, or via the ` cmd/ctrl + k ` shortcut - clicking any of the individual links directly will cause them to open in your browser when you press them.
 
 Note: In the header of related links, you can see the _total number_ of related links that you have.
@@ -94,11 +96,13 @@ From inside the Related Links drawer, you can add new links by typing them direc
 **You can quickly copy any related link from inside the Related Links Drawer by pressing the copy button on the right side of the Related link pill**
 
 | screenshot of an auto generated related link |
+
 **Auto Generated**
 - links that are added the moment you save a resource to Pieces, and contain a `sparkle` icon proceeding the tag name
 - also will include the favicon of the website it has come from inside the related link pill
 
 | screenshot of a custom related link |
+
 **Custom Links**:
 - links that you can write yourself and add to your code, that will not contain the sparkle icon
 - will still include the favicon of the website
@@ -113,14 +117,16 @@ To remove a specific link from the resource it is attached to, inside the Relate
 
 ---
 
-### Sharable Links `cmd + l` or `ctrl + l`
+### Sharable Links: `cmd + l` | `ctrl + l`
 Sharable links are accessible from this view, and can be opened using the `cmd/ctrl + l` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
 
 **Note that all Resources have their own unique sharable link, and each have to be generated on their own.**
 
 Read about all the ins and outs of sharable links on the [One Click Snippet Sharing Page](#).
 
-### Related People `cmd + p` or `ctrl + p`
+---
+
+### Related People: `cmd + p` | `ctrl + p`
 To facilitate communication among and between teams, Pieces for Developers attaches Related People to your saved snippets. Related People include content authors, open-source maintainers, GitHub collaborators, and others who are part of a snippet’s context.
 
 To access related People, you can click the Related People section or press the ```cmd/ctrl + p``` shortcut.
@@ -142,21 +148,15 @@ It requires two fields:
 
 If a related person is added to your list of People and you wish to remove it, you can do so by clicking the 'edit' pencil icon when you hover the Related Person in the Related People Drawer. Once you are in the edit drawer, you can click "Delete" next to the "Save" Button on the bottom of the drawer and the Related Person will be removed.
 
-### Smart Warnings and Sensitive Information Detection
-Some of the most commonly saved snippets are Powershell and Command Line instructions, boilerplate for unit tests, .env variables, HTTP requests, and CI/CD build configs. These often contain sensitive data like API keys, auth tokens, usernames, passwords, or service account credentials.
-
 ---
 
 ### Security Practices
-
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SENSITIVE.gif" />
 
 <a target="_blank" href="https://pieces.app">Pieces for Developers</a> facilitates security and programming best practices by detecting sensitive information and warning against accidental uploads or sharing.
 
-#### Protecting Context
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
+#### Smart Warnings and Sensitive Information Detection
+Some of the most commonly saved snippets are Powershell and Command Line instructions, boilerplate for unit tests, .env variables, HTTP requests, and CI/CD build configs. These often contain sensitive data like API keys, auth tokens, usernames, passwords, or service account credentials.
 
-In an effort to maintain this invaluable context, Pieces for Developers automatically extracts and associates useful origin details every time you save a resource.
 
-> Project Name, Source File, Line Numbers, Collaborators, Solution Publishers, Application Source, etc.
 

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -117,7 +117,7 @@ To remove a specific link from the resource it is attached to, inside the Relate
 
 ---
 
-### Sharable Links: `cmd + l` | `ctrl + l`
+### Sharable Links: `cmd + l` <Heading type="h5">or</Heading> `ctrl + l`
 Sharable links are accessible from this view, and can be opened using the `cmd/ctrl + l` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
 
 **Note that all Resources have their own unique sharable link, and each have to be generated on their own.**

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -29,7 +29,6 @@ Saving a snippet’s original context is helpful for organization and future use
 - Application Source (Chrome, Edge, VS Code, etc.)
 - Solution Publishers
 
-
 ---
 
 ## Inside the Context View

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -8,14 +8,27 @@ description: Learn how Pieces for Developers uses ML and AI with ChatGPT to enri
 # Auto-Enrichment
 Pieces for Developers enriches your content as you save snippets and makes it easy to get back to where you originally saved your code.
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
+<Image alt={"Viewing automatically captured metadata in Pieces for Developers."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
 
-## How to View Metadata & Enrichment Details ` cmd + i ` | ` ctrl + i `
+## View Metadata & Enrichment Details
+
+` cmd/ctrl + i `
+
 All background processing that goes into Pieces gives you the ability to access more data around your resources and code snippets. You can view the information by:
 - Press ```cmd + i``` or ```ctrl + i``` to access the Context View
 - [In List View] pressing the _view all context_ button on the top right of the context preview
 - [In Gallery View] press the _manage context_ on the overlay when hovering the 'view all context' button or press the 'view all context' icon itself
     - when hovering this icon you can also click the 'gear' icon to manage how often the overlay appears. [Read more about managing settings here](#)
+
+### Saving a Snippets Context
+Saving a snippet’s original context is helpful for organization and future use. Pieces automatically extracts the following contextual information:
+- Project Name
+- Source File
+- Line Numbers
+- Collaborators
+- Application Source (Chrome, Edge, VS Code, etc.)
+- Solution Publishers
+
 
 ---
 
@@ -24,7 +37,10 @@ Once you enter the Context view, you will see data added both [automatically via
 
 Whether you are in List or Gallery View, you will have access to the same set of sections.
 
-### Description: ` cmd + shift + n ` | ` ctrl + shift + n `
+### Description
+
+` cmd/ctrl + shift + n `
+
 You can press the entire _description_ box to open the "Edit Description Drawer" or use the ` cmd/ctrl + shift + n ` shortcut to edit the contents of the description context field.
 
 This section will by default be filled out, and you can reference the following example:
@@ -55,7 +71,10 @@ A few things to note about this format:
 
 ---
 
-### Tags: `cmd + t` | `ctrl + t`
+### Tags
+
+` cmd/ctrl + T `
+
 Open the Tags drawer by clicking anywhere overtop of the tags section, or by pressing the ` cmd/ctrl + t ` shortcut. This will bring pull up a list of tags that have already been [added when you saved the resource](#), along with suggested snippets that you can click to quickly add to the snippet.
 
 To create a custom tag, you can start typing once the drawer opens and add any tag you like directly into the preexisting tags list.
@@ -67,7 +86,7 @@ Example Tags:
 | screenshot of an auto generated tag |
 **Auto Generated**: tags that are added the moment you save a resource to Pieces, and contain a `sparkle` icon proceeding the tag name
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/AI_GENERATED_SMART_CONTEXT.gif" />
+<Image alt={"AI smart context example inside of Pieces Desktop."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/AI_GENERATED_SMART_CONTEXT.gif" />
 
 **Custom Tags**: tags that you can write yourself and add to your code, that will not contain the sparkle icon
 
@@ -75,20 +94,23 @@ Example Tags:
 | screenshot of a tag with the x hovered |
 
 To remove a tag:
-- Press the `X` icon to the right of a tag's title
+- Press the ` X ` icon to the right of a tag's title
 - A dialog will open up, and you can press "Delete" to confirm the removal of the tag
-    - You can also press `enter` or `return`
-- To cancel the deletion, press `esc` to go back to the tags drawer
+    - You can also press ` enter ` or ` return `
+- To cancel the deletion, press ` esc ` to go back to the tags drawer
 - (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
 
 ---
 
-### Related Links: `cmd + k` | `ctrl + k`
+### Related Links
+
+` cmd/ctrl + K `
+
 Related links can be opened by clicking on the _background_ of the related links section, or via the ` cmd/ctrl + k ` shortcut - clicking any of the individual links directly will cause them to open in your browser when you press them.
 
 Note: In the header of related links, you can see the _total number_ of related links that you have.
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_LINKS_EXTERNAL_RESOURCES.gif" />
+<Image alt={"Saving a snippet from Stack Overflow with the Pieces web extension"} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_LINKS_EXTERNAL_RESOURCES.gif" />
 
 #### Managing Related Links
 From inside the Related Links drawer, you can add new links by typing them directly into the text box at the top. Not all text input will be accepted, so it is important to add **a full http url** such as the following: [https://pieces.app/blog]()
@@ -98,7 +120,7 @@ From inside the Related Links drawer, you can add new links by typing them direc
 | screenshot of an auto generated related link |
 
 **Auto Generated**
-- links that are added the moment you save a resource to Pieces, and contain a `sparkle` icon proceeding the tag name
+- links that are added the moment you save a resource to Pieces, and contain a ` sparkle ` icon proceeding the tag name
 - also will include the favicon of the website it has come from inside the related link pill
 
 | screenshot of a custom related link |
@@ -109,16 +131,19 @@ From inside the Related Links drawer, you can add new links by typing them direc
 
 #### Deleting Related Links
 To remove a specific link from the resource it is attached to, inside the Related Links drawer:
-- Press the `trashcan` icon next to the `copy` icon on the right side of the related link
-- A confirmation drawer will open up, where you can confirm the removal by pressing `Delete` button
-    - You can also press `enter` or `return`
-- To cancel the deletion, press `esc` to go back to the Related Links drawer
+- Press the ` trashcan ` icon next to the ` copy ` icon on the right side of the related link
+- A confirmation drawer will open up, where you can confirm the removal by pressing ` Delete ` button
+    - You can also press ` enter ` or ` return `
+- To cancel the deletion, press ` esc ` to go back to the Related Links drawer
 - (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
 
 ---
 
-### Sharable Links: `cmd + l` <Heading type="h5">or</Heading> `ctrl + l`
-Sharable links are accessible from this view, and can be opened using the `cmd/ctrl + l` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
+### Sharable Links
+
+` cmd/ctrl + L `
+
+Sharable links are accessible from this view, and can be opened using the ` cmd/ctrl + L ` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
 
 **Note that all Resources have their own unique sharable link, and each have to be generated on their own.**
 
@@ -126,12 +151,15 @@ Read about all the ins and outs of sharable links on the [One Click Snippet Shar
 
 ---
 
-### Related People: `cmd + p` | `ctrl + p`
+### Related People
+
+` cmd/ctrl + P `
+
 To facilitate communication among and between teams, Pieces for Developers attaches Related People to your saved snippets. Related People include content authors, open-source maintainers, GitHub collaborators, and others who are part of a snippet’s context.
 
-To access related People, you can click the Related People section or press the ```cmd/ctrl + p``` shortcut.
+To access related People, you can click the Related People section or press the ``` cmd/ctrl + p ``` shortcut.
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
+<Image alt={""} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
 
 #### Managing Related People
 If a snippet is saved from a location locally that has no crossover with other users, it is likely that when you save a snippet it will have the following message:
@@ -151,7 +179,7 @@ If a related person is added to your list of People and you wish to remove it, y
 ---
 
 ### Security Practices
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SENSITIVE.gif" />
+<Image alt={"Protecting Sensitive information from being shared."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SENSITIVE.gif" />
 
 <a target="_blank" href="https://pieces.app">Pieces for Developers</a> facilitates security and programming best practices by detecting sensitive information and warning against accidental uploads or sharing.
 

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -8,88 +8,155 @@ description: Learn how Pieces for Developers uses ML and AI with ChatGPT to enri
 # Auto-Enrichment
 Pieces for Developers enriches your content as you save snippets and makes it easy to get back to where you originally saved your code.
 
-## Origin Details
-When you save something to <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a>, it not only saves the material itself; but further, our Context Awareness Engine and Origin Details automatically attach related context & metadata, enabling powerful organization, search, and suggestion capabilities.
+## How to View Metadata & Enrichment Details
+All background processing that goes into Pieces gives you the ability to access more data around your resources and code snippets. You can view the information by:
+- Press ```cmd + i``` or ```ctrl + i``` to access the Context View
+- [In List View] pressing the _view all context_ button on the top right of the context preview
+- [In Gallery View] press the _manage context_ on the overlay when hovering the 'view all context' button or press the 'view all context' icon itself
+    - when hovering this icon you can also click the 'gear' icon to manage how often the overlay appears. [Read more about managing settings here](#)
 
-**Reference code is everywhere these days. Whether it's a solution that you're adapting from Stack Overflow or doc-site boilerplate sent over Slack or Microsoft Teams, all code comes from somewhere.**
+---
 
-Where a code snippet came from and the larger context it was taken out of is often lost when saving or sharing reference materials, making it incredibly difficult to find, share, or reuse it later on.
+## Inside the Context View
+Once you enter the Context view, you will see data added both [automatically via Pieces AI & GPT4](), and also that you have [added manually]().
 
+Whether you are in List or Gallery View, you will have access to the same set of sections.
 
-## Protecting Context
+### Description `cmd + shift + n` or `ctrl + shift + n`
+You can press the entire _description_ box to open the "Edit Description Drawer" or use the `cmd/ctrl + shift + n` shortcut to edit the contents of the description context field.
 
+This section will by default be filled out, and you can reference the following example:
+
+``` text
+📝 Custom Description:
+Write a custom description here.
+
+💡 Smart Description:
+The article explains how to use the Snipping Tool feature in Windows to capture screenshots.
+
+🔎 Suggested Searches:
+Windows screenshot tool
+How to capture screenshots on Windows
+Microsoft support screenshot guide
+Windows snipping tool tutorial
+Windows screenshot shortcut
+```
+
+A few things to note about this format:
+**Custom Description**
+    - Comes default filled out as "Write a custom description" and is used as a space for you to write your own description
+**Smart Description**
+    - We auto generate this description and is used for search-ability, reading through your list of snippets, and is a description of what the snippet does.
+        - [you can use this feature to identify what a code snippet can do when you aren't sure](#)
+**Suggested Searches**
+    - These are great search terms that you can use to find snippets that are similar to the resource they are attached to. These are good examples that you can compare to the examples found on the [Global Search Page]() and try them in the app.
+
+---
+
+### Tags `cmd + t` or `ctrl + t`
+Open the Tags drawer by clicking anywhere overtop of the tags section, or by pressing the ` cmd/ctrl + t ` shortcut. This will bring pull up a list of tags that have already been [added when you saved the resource](#), along with suggested snippets that you can click to quickly add to the snippet.
+
+To create a custom tag, you can start typing once the drawer opens and add any tag you like directly into the preexisting tags list.
+
+Example Tags:
+``` HTTP Request ```, ``` Flutter Framework ```, ``` Dart Project ```, ``` Conditional For Loop ```
+
+#### Types of Tags
+| screenshot of an auto generated tag |
+**Auto Generated**: tags that are added the moment you save a resource to Pieces, and contain a `sparkle` icon proceeding the tag name
+
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/AI_GENERATED_SMART_CONTEXT.gif" />
+
+**Custom Tags**: tags that you can write yourself and add to your code, that will not contain the sparkle icon
+
+#### Removing Tags
+| screenshot of a tag with the x hovered |
+
+To remove a tag:
+- Press the `X` icon to the right of a tag's title
+- A dialog will open up, and you can press "Delete" to confirm the removal of the tag
+    - You can also press `enter` or `return`
+- To cancel the deletion, press `esc` to go back to the tags drawer
+- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
+
+---
+
+### Related Links `cmd + k` or `ctrl + k`
+Related links can be opened by clicking on the _background_ of the related links section, or via the ` cmd/ctrl + k ` shortcut - clicking any of the individual links directly will cause them to open in your browser when you press them.
+
+Note: In the header of related links, you can see the _total number_ of related links that you have.
+
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_LINKS_EXTERNAL_RESOURCES.gif" />
+
+#### Managing Related Links
+From inside the Related Links drawer, you can add new links by typing them directly into the text box at the top. Not all text input will be accepted, so it is important to add **a full http url** such as the following: [https://pieces.app/blog]()
+
+**You can quickly copy any related link from inside the Related Links Drawer by pressing the copy button on the right side of the Related link pill**
+
+| screenshot of an auto generated related link |
+**Auto Generated**
+- links that are added the moment you save a resource to Pieces, and contain a `sparkle` icon proceeding the tag name
+- also will include the favicon of the website it has come from inside the related link pill
+
+| screenshot of a custom related link |
+**Custom Links**:
+- links that you can write yourself and add to your code, that will not contain the sparkle icon
+- will still include the favicon of the website
+
+#### Deleting Related Links
+To remove a specific link from the resource it is attached to, inside the Related Links drawer:
+- Press the `trashcan` icon next to the `copy` icon on the right side of the related link
+- A confirmation drawer will open up, where you can confirm the removal by pressing `Delete` button
+    - You can also press `enter` or `return`
+- To cancel the deletion, press `esc` to go back to the Related Links drawer
+- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
+
+---
+
+### Sharable Links `cmd + l` or `ctrl + l`
+Sharable links are accessible from this view, and can be opened using the `cmd/ctrl + l` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
+
+**Note that all Resources have their own unique sharable link, and each have to be generated on their own.**
+
+Read about all the ins and outs of sharable links on the [One Click Snippet Sharing Page](#).
+
+### Related People `cmd + p` or `ctrl + p`
+To facilitate communication among and between teams, Pieces for Developers attaches Related People to your saved snippets. Related People include content authors, open-source maintainers, GitHub collaborators, and others who are part of a snippet’s context.
+
+To access related People, you can click the Related People section or press the ```cmd/ctrl + p``` shortcut.
+
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
+
+#### Managing Related People
+If a snippet is saved from a location locally that has no crossover with other users, it is likely that when you save a snippet it will have the following message:
+-  "No People Detected"
+    - The advantage to saving snippets by [importing them from GitHub gists](#) is other users who have commented on the PR, contributed to the repo, or any other involvement will show up here under related users. [Learn more about Migrating from GitHub to Pieces Desktop](#)
+
+#### Adding Related People Manually
+You can add related people manually with their name and email to any resource. When you share that resource, the information that you have attached will be included.
+- Learn about [using Related People to share code along with contacts to work with]
+
+It requires two fields:
+1. A name for the user to display in the related people section
+2. An email for the user that is related to the snippet.
+
+If a related person is added to your list of People and you wish to remove it, you can do so by clicking the 'edit' pencil icon when you hover the Related Person in the Related People Drawer. Once you are in the edit drawer, you can click "Delete" next to the "Save" Button on the bottom of the drawer and the Related Person will be removed.
+
+### Smart Warnings and Sensitive Information Detection
+Some of the most commonly saved snippets are Powershell and Command Line instructions, boilerplate for unit tests, .env variables, HTTP requests, and CI/CD build configs. These often contain sensitive data like API keys, auth tokens, usernames, passwords, or service account credentials.
+
+---
+
+### Security Practices
+
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SENSITIVE.gif" />
+
+<a target="_blank" href="https://pieces.app">Pieces for Developers</a> facilitates security and programming best practices by detecting sensitive information and warning against accidental uploads or sharing.
+
+#### Protecting Context
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
 
 In an effort to maintain this invaluable context, Pieces for Developers automatically extracts and associates useful origin details every time you save a resource.
 
 > Project Name, Source File, Line Numbers, Collaborators, Solution Publishers, Application Source, etc.
-
-## AI-Generated Smart Labels
-Doubling down on our efforts to make search and suggestion world-class, Pieces for Developers ships with an offline and on-device ML Material Labeling model that automatically generates smart labels for everything you save.
-
-> “HTTP Request”, “Flutter Framework”, "Dart Project", "Conditional For Loop"
-
-
-## User Added Tags
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/AI_GENERATED_SMART_CONTEXT.gif" />
-
-In addition to our auto-generated smart labels, our Context Awareness Engine automatically layers in tags that correspond to origin details and related links.
-
-You can easily add your own tags as a manual way to further organize your saved resources while driving a more personalized search and suggestion experience.
-
-> Our users are saving more than ever. That said, a large part of our material enrichment efforts are allocated toward making searches and suggestions first-class.
-
-
-## AI-Generated Smart Descriptions
-With these goals in mind, Pieces for Developers ships with an offline and on-device ML Material Description model that generates a smart description for everything you save.
-
-> e.g., What the code snippet or resource is, what it does, how to use it, and how it might be used in the future.
-
----
-
-## Associated Commit Messages
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SMART_DESCRIPTION.gif" />
-
-These smart descriptions, coupled with relevant commit messages extracted via our Context Awareness Engine, enable awesome reference and reuse experiences later on in a user's workflow.
-
-
-
-## Related People
-These days, technical work is more people-centric than ever. Writing and reviewing code, upskilling on ever-evolving best practices, migrating to new framework versions, and onboarding new developers— it all builds on the work of others.
-
-It's a challenge simply to know who to reach out to for additional context, who to add as a reviewer on pull requests, or who might provide a different perspective to save some serious time and prevent major headaches.
-
----
-
-## What problem does this solve?
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
-
-To help solve this dilemma, our Context Awareness Engine automatically associates Relevant Collaborators, Maintainers, and Content Authors with the resources you save.
-
-
-## Related Links, External Resources, & Reference Materials
-More and more developer resources live online nowadays. Saving the links you found while researching or problem-solving in the browser, code, or documentation has never been easier.
-
----
-
-## What type of Links?
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_LINKS_EXTERNAL_RESOURCES.gif" />
-
-With <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a>, you can quickly associate URLs to external resources like Documentation Pages, Wiki Links, Jira Tickets, Pull Requests, and <a target="_blank" href="{{ links.internal.personalized_link_sharing.share_via_github_gist }}">GitHub Issues </a>with your saved materials.
-
-
-## Smart Warnings and Sensitive Information Detection
-Some of the most commonly saved snippets are Powershell and Command Line instructions, boilerplate for unit tests, .env variables, HTTP requests, and CI/CD build configs. These often contain sensitive data like API keys, auth tokens, usernames, passwords, or service account credentials.
-
----
-
-## Security Practices
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SENSITIVE.gif" />
-
-<a target="_blank" href="https://pieces.app">Pieces for Developers</a> facilitates security and programming best practices by detecting sensitive information and warning against accidental uploads or sharing.
 

--- a/docs/features/auto-enrichment.mdx
+++ b/docs/features/auto-enrichment.mdx
@@ -8,17 +8,21 @@ description: Learn how Pieces for Developers uses ML and AI with ChatGPT to enri
 # Auto-Enrichment
 Pieces for Developers enriches your content as you save snippets and makes it easy to get back to where you originally saved your code.
 
+[To learn how to Manage and Update Snippets and their metadata, click this](/features/managing-saved-materials)
+
 <Image alt={"Viewing automatically captured metadata in Pieces for Developers."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/PFD_ORIGIN.gif" />
 
 ## View Metadata & Enrichment Details
 
-` cmd/ctrl + i `
+Shortcut: ` cmd/ctrl + i `
 
 All background processing that goes into Pieces gives you the ability to access more data around your resources and code snippets. You can view the information by:
-- Press ```cmd + i``` or ```ctrl + i``` to access the Context View
+- Press ` cmd + i ` or ` ctrl + i ` to access the Context View
 - [In List View] pressing the _view all context_ button on the top right of the context preview
 - [In Gallery View] press the _manage context_ on the overlay when hovering the 'view all context' button or press the 'view all context' icon itself
-    - when hovering this icon you can also click the 'gear' icon to manage how often the overlay appears. [Read more about managing settings here](#)
+    - when hovering this icon you can also click the 'gear' icon to manage how often the overlay appears.
+
+[//]: # ([Read more about managing settings here]&#40;#&#41;)
 
 ### Saving a Snippets Context
 Saving a snippet’s original context is helpful for organization and future use. Pieces automatically extracts the following contextual information:
@@ -32,15 +36,15 @@ Saving a snippet’s original context is helpful for organization and future use
 ---
 
 ## Inside the Context View
-Once you enter the Context view, you will see data added both [automatically via Pieces AI & GPT4](), and also that you have [added manually]().
+Once you enter the Context view, you will see data added both automatically via Pieces AI & GPT4, and also that you have [added manually](/features/managing-saved-materials).
 
 Whether you are in List or Gallery View, you will have access to the same set of sections.
 
 ### Description
 
-` cmd/ctrl + shift + n `
+Shortcuts: ` cmd/ctrl + shift + N `
 
-You can press the entire _description_ box to open the "Edit Description Drawer" or use the ` cmd/ctrl + shift + n ` shortcut to edit the contents of the description context field.
+You can press the entire _description_ box to open the "Edit Description Drawer" or use the ` cmd/ctrl + shift + N ` shortcut to edit the contents of the description context field.
 
 This section will by default be filled out, and you can reference the following example:
 
@@ -64,17 +68,19 @@ A few things to note about this format:
     - Comes default filled out as "Write a custom description" and is used as a space for you to write your own description
 **Smart Description**
     - We auto generate this description and is used for search-ability, reading through your list of snippets, and is a description of what the snippet does.
-        - [you can use this feature to identify what a code snippet can do when you aren't sure](#)
+
+[//]: # (        - [you can use this feature to identify what a code snippet can do when you aren't sure]&#40;#&#41;)
+
 **Suggested Searches**
-    - These are great search terms that you can use to find snippets that are similar to the resource they are attached to. These are good examples that you can compare to the examples found on the [Global Search Page](#) and try them in the app.
+    - These are great search terms that you can use to find snippets that are similar to the resource they are attached to. These are good examples that you can compare to the examples found on the [Global Search Page](/features/global-search) and try them in the app.
 
 ---
 
 ### Tags
 
-` cmd/ctrl + T `
+Shortcut: ` cmd/ctrl + t `
 
-Open the Tags drawer by clicking anywhere overtop of the tags section, or by pressing the ` cmd/ctrl + t ` shortcut. This will bring pull up a list of tags that have already been [added when you saved the resource](#), along with suggested snippets that you can click to quickly add to the snippet.
+Open the Tags drawer by clicking anywhere overtop of the tags section, or by pressing the ` cmd/ctrl + t ` shortcut. This will bring pull up a list of tags that have already been [added when you saved the resource](/product-highlights-and-benefits/in-project-snippet-discovery), along with suggested snippets that you can click to quickly add to the snippet.
 
 To create a custom tag, you can start typing once the drawer opens and add any tag you like directly into the preexisting tags list.
 
@@ -90,20 +96,20 @@ Example Tags:
 **Custom Tags**: tags that you can write yourself and add to your code, that will not contain the sparkle icon
 
 #### Removing Tags
-| screenshot of a tag with the x hovered |
-
 To remove a tag:
 - Press the ` X ` icon to the right of a tag's title
 - A dialog will open up, and you can press "Delete" to confirm the removal of the tag
     - You can also press ` enter ` or ` return `
 - To cancel the deletion, press ` esc ` to go back to the tags drawer
-- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
+- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions.
+
+[//]: # ([Read more about managing your settings]&#40;#&#41;)
 
 ---
 
 ### Related Links
 
-` cmd/ctrl + K `
+Shortcut: ` cmd/ctrl + k `
 
 Related links can be opened by clicking on the _background_ of the related links section, or via the ` cmd/ctrl + k ` shortcut - clicking any of the individual links directly will cause them to open in your browser when you press them.
 
@@ -116,13 +122,9 @@ From inside the Related Links drawer, you can add new links by typing them direc
 
 **You can quickly copy any related link from inside the Related Links Drawer by pressing the copy button on the right side of the Related link pill**
 
-| screenshot of an auto generated related link |
-
 **Auto Generated**
 - links that are added the moment you save a resource to Pieces, and contain a ` sparkle ` icon proceeding the tag name
 - also will include the favicon of the website it has come from inside the related link pill
-
-| screenshot of a custom related link |
 
 **Custom Links**:
 - links that you can write yourself and add to your code, that will not contain the sparkle icon
@@ -134,46 +136,47 @@ To remove a specific link from the resource it is attached to, inside the Relate
 - A confirmation drawer will open up, where you can confirm the removal by pressing ` Delete ` button
     - You can also press ` enter ` or ` return `
 - To cancel the deletion, press ` esc ` to go back to the Related Links drawer
-- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions. [Read more about managing your settings]
+- (optional) you can press "Do not ask me again" to quickly delete a number of tags from a snippet, but we recommend keeping this setting turned on to protect against accidental deletions.
 
 ---
 
 ### Sharable Links
 
-` cmd/ctrl + L `
+Shortcut: ` cmd/ctrl + l `
 
-Sharable links are accessible from this view, and can be opened using the ` cmd/ctrl + L ` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
+Sharable links are accessible from this view, and can be opened using the ` cmd/ctrl + l ` shortcut or by clicking on the section inside the Context View. This will open the Sharable Link Drawer where you can manage the sharable link for a specific resource.
 
 **Note that all Resources have their own unique sharable link, and each have to be generated on their own.**
 
-Read about all the ins and outs of sharable links on the [One Click Snippet Sharing Page](#).
+Read about all the ins and outs of sharable links on the [One Click Snippet Sharing Page](/features/one-click-snippet-sharing).
 
 ---
 
 ### Related People
 
-` cmd/ctrl + P `
+Shortcut: ` cmd/ctrl + p `
 
 To facilitate communication among and between teams, Pieces for Developers attaches Related People to your saved snippets. Related People include content authors, open-source maintainers, GitHub collaborators, and others who are part of a snippet’s context.
 
-To access related People, you can click the Related People section or press the ``` cmd/ctrl + p ``` shortcut.
+To access related People, you can click the Related People section or press the ` cmd/ctrl + p ` shortcut.
 
-<Image alt={""} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
+<Image alt={"Showing related people on a snippet with a sharable link."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RELATED_PEOPLE.gif" />
 
 #### Managing Related People
 If a snippet is saved from a location locally that has no crossover with other users, it is likely that when you save a snippet it will have the following message:
 -  "No People Detected"
-    - The advantage to saving snippets by [importing them from GitHub gists](#) is other users who have commented on the PR, contributed to the repo, or any other involvement will show up here under related users. [Learn more about Migrating from GitHub to Pieces Desktop](#)
+    - The advantage to saving snippets by [importing them from GitHub gists](/product-highlights-and-benefits/import-gists-from-github) is other users who have commented on the PR, contributed to the repo, or any other involvement will show up here under related users.
+
+[//]: # ([Learn more about Migrating from GitHub to Pieces Desktop]&#40;#&#41;)
 
 #### Adding Related People Manually
 You can add related people manually with their name and email to any resource. When you share that resource, the information that you have attached will be included.
-- Learn about [using Related People to share code along with contacts to work with]
 
 It requires two fields:
 1. A name for the user to display in the related people section
 2. An email for the user that is related to the snippet.
 
-If a related person is added to your list of People and you wish to remove it, you can do so by clicking the 'edit' pencil icon when you hover the Related Person in the Related People Drawer. Once you are in the edit drawer, you can click "Delete" next to the "Save" Button on the bottom of the drawer and the Related Person will be removed.
+If a related person is added to your list of People and you wish to remove it, you can do so by clicking the ` edit ` pencil icon when you hover the Related Person in the Related People Drawer. Once you are in the edit drawer, you can click ` delete ` next to the ` save ` Button on the bottom of the drawer and the Related Person will be removed.
 
 ---
 

--- a/docs/features/creation-and-generation.mdx
+++ b/docs/features/creation-and-generation.mdx
@@ -12,9 +12,9 @@ Utilizing the power of ChatGPT, in-house models, and other strategies employed b
 Use natural language to fully describe the code that will assist you in your project from the "Describe a Snippet" menu. You can access this menu by:
 1. Opening the "Describe a Snippet" Overlay:
     - Selecting the "Add +" button beneath the carousel
-    - Pressing ```CMD + Shift + P / CTRL + Shift + P``` to open the overlay immediately
+    - Pressing ``` cmd + shift + P / ctrl + shift + p ``` to open the overlay immediately
 
-2. After the menu opens, you can begin typing in the search bar (marked with a ">"). Here is an example phrase for you to try: ```split a string based on spaces and print each item```
+2. After the menu opens, you can begin typing in the search bar (marked with a ">"). Here is an example phrase for you to try: ``` split a string based on spaces and print each item ```
 
     **Before pressing enter - be sure to set the language to the output language that you would like to get back. This will be automatically set to the same language as the last snippet that you were focused on in your carousel.**
 

--- a/docs/features/global-search.mdx
+++ b/docs/features/global-search.mdx
@@ -18,13 +18,13 @@ To access Global Search in the Pieces desktop app, select Global Search from the
 
 | GLOBAL SEARCH SCREENSHOT IN DROPDOWN HERE |
 
-Once you arrive at the [Global Search View](#), you can start to type into the search bar located at the top of the app. You can either press ```/``` to toggle into the search bar, or click to select it.
+Once you arrive at the **Global Search View**, you can start to type into the search bar located at the top of the app. You can either press ``` / ``` to toggle into the search bar, or click to select it.
 
 This is the Global Search Bar - which is where you will type the semantic search terms to find what you are looking for.
 
 Some other helpful information:
-- You can press ```esc``` 2x to clear the search bar
-- You can press ```esc``` (when the search bar is not focused) to navigate back to the list view or gallery view, depending on which you came from
+- You can press ``` esc ``` 2x to clear the search bar
+- You can press ``` esc ``` (when the search bar is not focused) to navigate back to the list view or gallery view, depending on which you came from
 
 ### Using Search Queries
 The queries here are limitless, but learning to craft the **right search** is important. Here are a few examples that we use every day and the types of snippets that are returned:
@@ -41,23 +41,23 @@ While there are a number of custom queries that you could type in every time, wh
 
 _To get a new set of suggested searches, simply press the "refresh" icon next to "Suggested Searches" above the pills._
 
-| GLOBAL SEARCH SUGGESTED SEARCH QUERIES HERE |
-
 ### Understanding Search Results
 When you perform a search, you will have three main sections that will show up pertaining to the query.
 1. The snippets that match your results will be in vertical cards containing:
     - The Title of the Snippet
     - The Description of the Snippet
     - An "Expand Code" dropdown to see a specific snippets code/text contents
-    - A [Productivity Score](#)
-    - (optional) a related link to the source that the resource came from i.e. saved using the [Chrome Extension](#)
+    - A Productivity Score that roughly estimates how much you use a snippet and how useful it is to you
+    - (optional) a related link to the source that the resource came from i.e. saved using the [Chrome Extension](/extensions-plugins/chrome)
 
 2. Related tags between the results that you have:
-    - Each tag that can be seen is included on one of the results, and can be clicked on to see which snippet they are connected to
+    - Each tag that can be seen is included on one of the results, and can be clicked on to see which other snippets they are connected to that have been returned in the search
 
 3. Related Links
     - The related links across the search results that you have
-        - Searching using a description such as "building widgets in flutter", then using the related links results to research about a topic is a great way to utilize this feature. Learn more about [searching and researching inside Pieces Desktop](#)
+        - Searching using a description such as "building widgets in flutter", then using the related links results to research about a topic is a great way to utilize this feature.
+
+[//]: # (   Learn more about [searching and researching inside Pieces Desktop]&#40;#&#41;)
 
 
 

--- a/docs/features/global-search.mdx
+++ b/docs/features/global-search.mdx
@@ -7,35 +7,60 @@ description: Use Global search to discover snippets you have saved based on what
 
 # Global Search
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/GLOBAL_SEARCH.gif" />
+<Image zoom alt={"Using Global Search in the Pieces desktop app"} src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/GLOBAL_SEARCH.gif" />
 
-Our <a target="_blank" href="https://docs.pieces.app/overview">Flagship Desktop App</a> makes it easier than ever to find what you need when you need it with a blazingly fast search experience.
+Global search allows you to [search for code semantically](#) to help you find something you may not know how to find. You can use whole sentences like "functions that transform arrays", or "flutter widgets that are stateful" to get code snippets related to the problem that you are trying to solve.
 
-Instantly find, reference, share or reuse your saved developer materials in a few keystrokes without breaking your flow.
+_If you are looking for more information about our Search types that can be toggled on the List or Gallery View - [go here](#)._
 
 ## How to Use Global Search
-Global search utilizes semantics to help you associate your search term with a solution to your problem. Many factors play into how and why a snippet shows up when you search and in what order.
+To access Global Search in the Pieces desktop app, select Global Search from the dropdown menu in the upper left corner where other views like [Workflow Activity](#), [Snippet Discovery](#), and more.
 
-## Adjust Settings for Optimal Search Results
-Pieces for Developers offers three ways to search within the Desktop App in order to quickly find what you need.
+| GLOBAL SEARCH SCREENSHOT IN DROPDOWN HERE |
 
-### Blended Search
-- Search via multiple query matches, including code, tags, descriptions, and links. This method can be particularly useful for users who need to search for specific information across a variety of sources.
+Once you arrive at the [Global Search View](#), you can start to type into the search bar located at the top of the app. You can either press ```/``` to toggle into the search bar, or click to select it.
 
-### Full-Text Search
-- Search for text values within code, documents, and other text-based sources. This method is particularly useful for users who are looking for specific words or phrases.
+This is the Global Search Bar - which is where you will type the semantic search terms to find what you are looking for.
 
-### Neural Code Search
-- Search by describing what you're looking for using natural language. This method can be particularly useful for users who are not familiar with the specific terminology used in code or who are looking for a more intuitive way to search for information.
+Some other helpful information:
+- You can press ```esc``` 2x to clear the search bar
+- You can press ```esc``` (when the search bar is not focused) to navigate back to the list view or gallery view, depending on which you came from
 
-## Sorting by Realtime or Scope-Relevant Suggestions
+### Using Search Queries
+The queries here are limitless, but learning to craft the **right search** is important. Here are a few examples that we use every day and the types of snippets that are returned:
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SORT.gif" />
+| Query | Result(s)  | Explaination  |
+|---|---|---|
+| csv file reader | Python Parse Data CSV, Importing Country Data | Python Parse Data CSV is self explainatory, but the description on 'Importing County Data' states it "loads a csv file from a URL and prints the first 5 rows. |
+| firebase deploy | Firebase Hosting Deployment with GitHub Actions | Related to 'deploying a firebase app' this user uses github frequently. |
+| promise helper | Promise Resolution Helper Function | Smart Tagged with 'Future' and description talks about sync |
+| js sleep function | CommonJS Conversion Function, Promise-based Sleep Function | Generated title match, code lannguage match, CommonJS related match |
 
-The demands on developers are increasing every day. As a result, a developer's time is becoming ever more precious and anything that boosts productivity is no longer a nice-to-have, but a need-to-have.
+## Suggested Searches
+While there are a number of custom queries that you could type in every time, why would you? When you are on the Global Search View, you can see a list of search queries generated **specific to the code you save**.
 
-With that, our team has invested serious resources into enabling Pieces for Developers to proactively suggest the most relevant materials at the right time.
+_To get a new set of suggested searches, simply press the "refresh" icon next to "Suggested Searches" above the pills._
 
-### Sorting via Scope Relevant Suggestions
-We're excited to for you to check out **Sorting via Suggestions**, which is based on your recently saved materials, available in our <a target="_blank" href="{{ links.website.pfd_desktop_install }}">Flagship Desktop App</a>.
+| GLOBAL SEARCH SUGGESTED SEARCH QUERIES HERE |
+
+### Understanding Search Results
+When you perform a search, you will have three main sections that will show up pertaining to the query.
+1. The snippets that match your results will be in vertical cards containing:
+    - The Title of the Snippet
+    - The Description of the Snippet
+    - An "Expand Code" dropdown to see a specific snippets code/text contents
+    - A [Productivity Score](#)
+    - (optional) a related link to the source that the resource came from i.e. saved using the [Chrome Extension](#)
+
+2. Related tags between the results that you have:
+    - Each tag that can be seen is included on one of the results, and can be clicked on to see which snippet they are connected to
+
+3. Related Links
+    - The related links across the search results that you have
+        - Searching using a description such as "building widgets in flutter", then using the related links results to research about a topic is a great way to utilize this feature. Learn more about [searching and researching inside Pieces Desktop](#)
+
+
+
+
+
 

--- a/docs/features/managing-saved-materials.mdx
+++ b/docs/features/managing-saved-materials.mdx
@@ -10,11 +10,11 @@ description: Once you save a material you can edit, rename, reclassify and modif
 <Image alt={"Editing a snippet in the Pieces desktop app."} zoom src={"https://storage.googleapis.com/pieces_static_resources/pfd_wiki/EDIT_SNIPPET_PFD.gif"} />
 
 ## Learning How to Update and Edit
-Once you save a material you can edit the snippets visible features - its title, and the contents of the resource itself. Access these features by clicking the `pencil icon` that is at the top of the Quick Action Menu on the right side of your Pieces Desktop window.
+Once you save a material you can edit the snippets visible features - its title, and the contents of the resource itself. Access these features by clicking the ` pencil icon ` that is at the top of the Quick Action Menu on the right side of your Pieces Desktop window.
 
 You can do one of two things here:
 - By clicking in where the code is in the center of the screen, you can edit the snippet directly
-- You can access transformations that can create boilerplate code and add comments for you. [Read about Snippet Transformations to know more](#)
+- You can access transformations that can create boilerplate code and add comments for you. [Read about Snippet Transformations to know more](/features/transforming-snippets)
 
 ### Editing saved Code Snippets and Text Notes Directly
 Once you select the code in the center of Pieces Desktop you have freedom to manipulate the text/code however you see fit with functionality similar to that of your IDE.
@@ -22,15 +22,15 @@ Once you select the code in the center of Pieces Desktop you have freedom to man
 - Your code syntax highlighting will update as you edit to ensure you are using valid syntax while making adjustments
 - You can right-click to cut, copy, paste, and select all
 
-To Exit edit mode, you can press `esc` or select the 'Exit Edit Mode' pill, and you will be taken back to the [list](#) or [gallery](#) view.
+To Exit edit mode, you can press ` esc ` or select the 'Exit Edit Mode' pill, and you will be taken back to the **list** or **gallery** view.
 
 ## Renaming Saved Materials
 
 <Image alt={"Renaming a snippet in the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RENAME_SNIPPET.gif" />
 
-Before working with renaming snippets, be sure to read about our [AI title generation](#) to get an idea of how title generation takes place.
+Before working with renaming snippets, be sure to read about our [AI title generation](/features/auto-enrichment) to get an idea of how title generation takes place.
 
-To rename a snippet quickly, press ` cmd/ctrl + R ` to toggle the title's 'Edit Mode'. You'll notice the title becomes highlighted, and you can begin typing immediately.
+To rename a snippet quickly, press ` cmd/ctrl + r ` to toggle the title's ` Edit Mode `. You'll notice the title becomes highlighted, and you can begin typing immediately.
 
 ## Reclassifying a Code Snippet's Language Association
 
@@ -39,8 +39,9 @@ To rename a snippet quickly, press ` cmd/ctrl + R ` to toggle the title's 'Edit 
 Each snippet that is added to Pieces passes through our language models to **classify the snippet for you if you do not already know the language**. Our classifier is not 100% accurate as it learns about each user. Some things to note before diving in:
 
 1. The classifier learns based on the code you save to Pieces, so if you only save Javascript Snippets this will increase the bias of Pieces to support that language.
-2. Inside the [Reclassification Drawer](#) you can see the classification confidence, which is a guide to help you select the relevant language for the code snippet when it is pasted. By reclassifying code when it is auto-classified as the wrong language to the correct language, tells your local model to _note_ the change that you made for the future, making it more likely to classify it correctly next time.
-[Learn more about impacting your AI profile here](#)
+2. Inside the [Reclassification Drawer](/features/managing-saved-materials#reclassifying-a-code-snippets-language-association) you can see the classification confidence, which is a guide to help you select the relevant language for the code snippet when it is pasted. By reclassifying code when it is auto-classified as the wrong language to the correct language, tells your local model to _note_ the change that you made for the future, making it more likely to classify it correctly next time.
+
+[//]: # ([Learn more about impacting your AI profile here]&#40;#&#41;)
 
 ### Instant Language Detection Support
 One of our fundamental capabilities is Instant Language Detection, which automatically detects the language of your snippet and supports over 40 programming languages:
@@ -92,15 +93,15 @@ One of our fundamental capabilities is Instant Language Detection, which automat
 
 <Image alt={"Deleting a snippet in the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DELETE_SNIPPET.gif" />
 
-Just as quickly as you add, you can remove snippets as well. To delete a resource you can simply press `delete`, or you can follow these steps:
+Just as quickly as you add, you can remove snippets as well. To delete a resource you can simply press ` delete `, or you can follow these steps:
 
 In list View:
 - Select the Snippet that you would like to delete
 - Select the ` ... ` on the bottom of the Quick Action Menu
 - Scroll to the bottom of the Context Menu, and once you get to the bottom of the drawer, you will see a section labeled "Danger Zone"
-- Select the "Delete Piece" Icon (you can also press `delete` from here as well)
+- Select the "Delete Piece" Icon (you can also press ` delete ` from here as well)
 - A new drawer will confirm your choice to delete the resource
-- You can click "Delete" or press `enter` to confirm
+- You can click ` delete ` or press ` enter ` to confirm
     - Please keep in mind that at this time, Pieces cannot retrieve a deleted resource
     - You can also choose “Don’t ask me again” to turn off the confirmation window
 

--- a/docs/features/managing-saved-materials.mdx
+++ b/docs/features/managing-saved-materials.mdx
@@ -7,32 +7,102 @@ description: Once you save a material you can edit, rename, reclassify and modif
 
 # Managing Saved Materials
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/EDIT_SNIPPET_PFD.gif" />
+<Image alt={"Editing a snippet in the Pieces desktop app."} zoom src={"https://storage.googleapis.com/pieces_static_resources/pfd_wiki/EDIT_SNIPPET_PFD.gif"} />
 
-Once you save a material you can edit, rename, reclassify and modify metadata to adjust it over time.
+## Learning How to Update and Edit
+Once you save a material you can edit the snippets visible features - its title, and the contents of the resource itself. Access these features by clicking the `pencil icon` that is at the top of the Quick Action Menu on the right side of your Pieces Desktop window.
 
-## Editing saved Code Snippets and Text Notes
+You can do one of two things here:
+- By clicking in where the code is in the center of the screen, you can edit the snippet directly
+- You can access transformations that can create boilerplate code and add comments for you. [Read about Snippet Transformations to know more](#)
 
-As we progress deeper into our projects, frameworks and dependencies often change, which means we might need to adjust a saved snippet to comply with breaking changes or conform to new standards. Click on the pencil in the upper-right corner of the Pieces Desktop App to quickly and easily edit a saved snippet so your code can stay relevant and up-to-date.
+### Editing saved Code Snippets and Text Notes Directly
+Once you select the code in the center of Pieces Desktop you have freedom to manipulate the text/code however you see fit with functionality similar to that of your IDE.
+
+- Your code syntax highlighting will update as you edit to ensure you are using valid syntax while making adjustments
+- You can right-click to cut, copy, paste, and select all
+
+To Exit edit mode, you can press `esc` or select the 'Exit Edit Mode' pill, and you will be taken back to the [list](#) or [gallery](#) view.
 
 ## Renaming Saved Materials
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RENAME_SNIPPET.gif" />
+<Image alt={"Renaming a snippet in the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RENAME_SNIPPET.gif" />
 
-We're on a mission to make it as frictionless as possible for our users to save snippets without disrupting their flow. The AI in Pieces for Developers will attempt to add a relevant name for your snippets automatically, so you don't have to. Don't worry, you can rename your snippets anytime to a convention that works best for you. All you need to do is right-click a snippet in the List View and select "Rename".
+Before working with renaming snippets, be sure to read about our [AI title generation](#) to get an idea of how title generation takes place.
+
+To rename a snippet quickly, press ` cmd/ctrl + R ` to toggle the title's 'Edit Mode'. You'll notice the title becomes highlighted, and you can begin typing immediately.
 
 ## Reclassifying a Code Snippet's Language Association
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RECLASSIFY_IN_PFD.gif" />
+<Image alt={"Reclassifying a snippet in the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/RECLASSIFY_IN_PFD.gif" />
 
-When you save a material to Pieces for Developers, our AI works hard to understand what you saved so that we can successfully add as much helpful metadata - tags, related links & websites, related people, etc. - as possible.
+Each snippet that is added to Pieces passes through our language models to **classify the snippet for you if you do not already know the language**. Our classifier is not 100% accurate as it learns about each user. Some things to note before diving in:
 
-One of our fundamental capabilities is Instant Language Detection, which automatically detects the language of your snippet and supports over 40 programming languages, including Typescript, Javascript, Python, Dart, C++, C#, and many more. Unfortunately, we don't always get it right, so we made it as easy as possible to reclassify a snippet to the proper language. Simply right-click a snippet in the List View and select "Reclassify".
+1. The classifier learns based on the code you save to Pieces, so if you only save Javascript Snippets this will increase the bias of Pieces to support that language.
+2. Inside the [Reclassification Drawer](#) you can see the classification confidence, which is a guide to help you select the relevant language for the code snippet when it is pasted. By reclassifying code when it is auto-classified as the wrong language to the correct language, tells your local model to _note_ the change that you made for the future, making it more likely to classify it correctly next time.
+[Learn more about impacting your AI profile here](#)
+
+### Instant Language Detection Support
+One of our fundamental capabilities is Instant Language Detection, which automatically detects the language of your snippet and supports over 40 programming languages:
+
+<Accordion title="Supported Languages">
+    - Batchfile
+    - C
+    - Clojure
+    - C#
+    - C++
+    - CoffeeScript
+    - CSS
+    - Dart
+    - Erlang
+    - Emacs Lisp
+    - Elixir
+    - Go
+    - Groovy
+    - Haskell
+    - HTML
+    - Java
+    - JavaScript
+    - JSON
+    - Kotlin
+    - Lua
+    - Markdown
+    - Matlab
+    - Objective-C
+    - Perl
+    - PHP
+    - PowerShell
+    - Python
+    - R
+    - Ruby
+    - Rust
+    - Scala
+    - Shell
+    - SQL
+    - Swift
+    - TeX
+    - Text
+    - TOML
+    - TypeScript
+    - XML
+    - YAML
+</Accordion>
 
 ## Deleting a Saved Material
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DELETE_SNIPPET.gif" />
+<Image alt={"Deleting a snippet in the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DELETE_SNIPPET.gif" />
 
-Since we made it so simple to save snippets from the <a target="_blank" href="{{ links.extensions.chrome }}">browser</a>, your IDE, or with our <a target="_blank" href="{{ links.website.pfd_desktop_install }}">Flagship Desktop App</a>, users are saving hundreds of snippets throughout their time researching, coding, and collaborating. For some, this can get a little chaotic. If you find yourself looking to do a little spring cleaning, you can delete snippets by hitting your delete key.
+Just as quickly as you add, you can remove snippets as well. To delete a resource you can simply press `delete`, or you can follow these steps:
+
+In list View:
+- Select the Snippet that you would like to delete
+- Select the ` ... ` on the bottom of the Quick Action Menu
+- Scroll to the bottom of the Context Menu, and once you get to the bottom of the drawer, you will see a section labeled "Danger Zone"
+- Select the "Delete Piece" Icon (you can also press `delete` from here as well)
+- A new drawer will confirm your choice to delete the resource
+- You can click "Delete" or press `enter` to confirm
+    - Please keep in mind that at this time, Pieces cannot retrieve a deleted resource
+    - You can also choose “Don’t ask me again” to turn off the confirmation window
+
 
 

--- a/docs/features/one-click-snippet-sharing.mdx
+++ b/docs/features/one-click-snippet-sharing.mdx
@@ -5,25 +5,30 @@ description: Developers, Technical Writers, Instructors, and many others in the 
 
 <link rel="canonical" href="https://docs.pieces.app/features/one-click-snippet-sharing" />
 
-# Single-click Link Sharing
-Developers, Technical Writers, Instructors, and many others in the space constantly share code snippets, error logs, configuration files, boilerplate, sample code, and other developer materials with their colleagues, readers, students, open-source maintainers, customers, and so on.
-
-For us, **sharing is not only about sending someone the code snippet or resource itself, but further, enabling the recipient to access both the material and its associated context metadata - where it came from, what it is, why it was saved, its description, git context, tags, additional collaborators, related links, and so much more**.
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/CUSTOM_SUBDOMAIN.gif" />
+# One-click Snippet Sharing
+Pieces snippet sharing allows you to send someone a code snippet and its context connected to a link that you generate inside of Pieces Desktop or one of our extensions.
 
 Effortlessly share code snippets, screenshots, and other resources with a personalized access link (e.g., _YOUR_USERNAME.pieces.cloud_), in just a few steps.
 
-- When you select a resource and generate a shareable link, that resource, along with all of its useful context, is uploaded to your private Pieces for Developers Cloud.
+## Getting Started with Sharing
+_Before getting started with snippet sharing, you will need to make sure that you are [signed in]() that way we can create space for your private cloud._
 
-From there, those with the link will be able to access what you shared and its context metadata, even if the recipient doesn't have Pieces for Developers themselves.
+1. After signing in and ensuring that you are [connected to the cloud](#), go to any snippet inside the desktop application
+2. Once you have the snippet selected, press the "Sharable Link" icon on the Action menu nested on the right side of your screen.
+    - [Learn how to generate a sharable link from inside our Extensions and Plugins](#)
+3. This will open up the "Shareable Link Drawer" that will have a few different possibilities:
+    - The link should already be present if you are connect to the cloud, or a spinner will be there with a message reading "Generating your sharable link"
+        - This process is normally only about 10 seconds (maximum)
+    - "Connect to cloud" will be present if your cloud connection did not complete automatically, but you can click the cloud icon to connect - [find out more about troubleshooting Cloud Connectivity](#)
+    - if you are _still_ not signed in, you can do this from here and the text box will read "Connect your Account"
 
-_Preview this <a target="_blank" href="{{ links.snippets.python.snippet }}">Shared Python Snippet</a> from _python.pieces.cloud_ in your browser! It's one of twenty useful snippets in our <a target="_blank" href="{{ links.snippets.python.collection }}">Curated Python Snippets Collection</a>._
+### Claiming a Custom Domain
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/CUSTOM_SUBDOMAIN.gif" />
 
-## Saving a Shared Material
-Although it's not necessary to have <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a> when accessing a shared resource, we don't want our users to have to switch back and forth to the browser or keep track of all the shareable links they've received.
+Creating a custom domain for
 
-Recipients that have <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a> can easily save a copy of the shared resource to their own Pieces for Developers repository for offline search, suggestion, and reuse later on.
+## Sending Someone a Saved Material
+In order to send someone a link to your shared resource, simply take the url from inside the
 
 ## Viewing Materials
 

--- a/docs/features/one-click-snippet-sharing.mdx
+++ b/docs/features/one-click-snippet-sharing.mdx
@@ -10,8 +10,10 @@ Pieces snippet sharing allows you to send someone a code snippet and its context
 
 Effortlessly share code snippets, screenshots, and other resources with a personalized access link (e.g., _YOUR_USERNAME.pieces.cloud_), in just a few steps.
 
-## Getting Started with Sharing
-_Before getting started with snippet sharing, you will need to make sure that you are [signed in]() that way we can create space for your private cloud._
+## Getting Started with Sharable Links
+_Before getting started with snippet sharing, you will need to make sure that you are [signed in](#) that way we can create space for your private cloud._
+
+<Image zoom alt={"Generating a shareable link in the Pieces desktop app"} src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHAREABLE_LINK.gif" />
 
 1. After signing in and ensuring that you are [connected to the cloud](#), go to any snippet inside the desktop application
 2. Once you have the snippet selected, press the "Sharable Link" icon on the Action menu nested on the right side of your screen.
@@ -22,49 +24,62 @@ _Before getting started with snippet sharing, you will need to make sure that yo
     - "Connect to cloud" will be present if your cloud connection did not complete automatically, but you can click the cloud icon to connect - [find out more about troubleshooting Cloud Connectivity](#)
     - if you are _still_ not signed in, you can do this from here and the text box will read "Connect your Account"
 
+### Sharing as a GitHub Gist
+Sharing as a Gist is a great alternative for sharable links if you want to post the code to your [public gists,](#) so they are accessible to more people without having to send them all a link individually.
+
+<Image zoom alt={"Sharing a snippet via GitHub Gist in the Pieces desktop app"} src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHARING_GISTS.gif" />
+
+To do this, navigate to the [Sharable Link Drawer](#) mentioned above, then:
+
+1. **Select the GitHub logo** to the right of your sharable link inside the input
+    - _If you have not authenticated with GitHub **you will have to** in order to generate a Gist_
+2. (optional) **Create a title and a description**
+    - you can create a title and a description from here, or you can skip this step and a generated title will be created for you
+3. **Press "Generate" and you'll get the link to the Gist**, and it can be found on your public gists on your GitHub account
+
+#### Bundled Metadata Preview
+Every Gist has a _Markdown Preview_ built using our <a target="_blank" href="{{ links.internal.context_awareness_engine.origin_details }}">Context Awareness Engine and Origin Details</a> which include relevant and related information to the snippet's context.
+
 ### Claiming a Custom Domain
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/CUSTOM_SUBDOMAIN.gif" />
 
-Creating a custom domain for
+Claiming your custom domain can be done from Pieces Desktop **only** - so be sure to [get the app](#) if you want to claim your unique domain.
+
+To claim your custom personal domain:
+1. Open up your settings by pressing ```,``` or by click your user icon (if you aren't [signed in via Google](#) you may not have one here)
+    - | would love to get some examples in here of the difference |
+2. Find "Claim your Domain" in the text box followed by .pieces.cloud
+3. Input the new unique name that you want (this will be on all of your sharable links)
+    - No special characters, no uppercase letters
+    - example: powersnippets.pieces.cloud
+
+**Important Note:** Updating your personal cloud domain can take up to 15 minutes. Don't worry, we'll notify you when this is complete.
 
 ## Sending Someone a Saved Material
-In order to send someone a link to your shared resource, simply take the url from inside the
+In order to send someone a link to your shared resource, simply take the url from inside the Sharable Link Drawer and paste it into places like:
+- GChat
+- Microsoft Teams ([we have an app for that](#))
+- Text Message via IOS Messenger or Android Messenger
 
-## Viewing Materials
+Each link that you generate and send looks slightly different, but all will be marked by your Custom Sharable link, just like in this example from our friends at [dart-tutorial](#):
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SAVE_FROM_WEB" />
+`https://snippets.pieces.cloud/` + `?p=111d45b730`
 
-Simply click the **_Save to Pieces_** button located at the top of the <a target="_blank" href="{{ links.internal.personalized_link_sharing.single_click_link_sharing }}">Sharing Preview Web App</a>, and you're good to go! You can now access and reuse the locally saved resource in our **Flagship Desktop App** or in your IDE with the <a target="_blank" href="{{ links.extensions.vscode }}">Pieces for Developers | VSCode Extension</a> or <a target="_blank" href="{{ links.extensions.jetbrains }}">Pieces for Developers | Jetbrains Plugin</a>.
+## Saving a Shared Material you Received
+<Image zoom alt={"Saving a snippet from the Pieces Share Web App"} src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SAVE_FROM_WEB" />
 
-## Editing and Revoking Shared Snippets
+When you receive a sharable link from someone, you can start by `cmd` or `ctrl` clicking the link that you received or pasting it into your browser, which will open up our [Share Web App](#) that allows you to view the shared material before saving it.
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHAREABLE_LINK.gif" />
+Once on this page, you can save the snippet to Pieces by pressing the 'Save to Pieces' button at the top of the page.
 
+You can now access and reuse the locally saved resource in the **Desktop App** or in your IDE with the <a target="_blank" href="{{ links.extensions.vscode }}">Pieces for Developers | VSCode Extension</a> or <a target="_blank" href="{{ links.extensions.jetbrains }}">Pieces for Developers | Jetbrains Plugin</a>.
+
+Try it out with this [python snippet](https://python.pieces.cloud/?p=8711459369)
+
+## Updating Access or Data attached to Shared Snippets
 If you edit the resource or add additional context metadata, <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a> will either recommend that you update the link or automatically update it for you. This happens in the background without generating a new access link, meaning previous recipients can stay up-to-date and you don't have to re-share.
 
 Lastly, we know that accidental shares happen and permission levels can change. With that, you can always revoke a shareable link at any time.
 
-## Share via GitHub Gist
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHARING_GISTS.gif" />
 
-When creating a shareable link to a snippet, you can also choose to share the snippet via GitHub Gist by creating the Gist directly from Pieces.
-
-Created Gists be available on your list of public Gists, making them available for others to discover as you create them. (You can also choose to generate a Private Gist.)
-
-### Bundled Metadata Preview
-Every Gist has a _Markdown Preview_ built using our <a target="_blank" href="{{ links.internal.context_awareness_engine.origin_details }}">Context Awareness Engine and Origin Details</a> which include relevant and related information to the snippet's context.
-
-## Connecting a Custom Cloud Domain
-
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/CUSTOM_SUBDOMAIN.gif" />
-
-Sharing materials using Pieces for Developers is about more than sharing the material itself. It's about sharing the material and all the contextual metadata associated with it - where it came from, what it does, how to use it, associated people, and more. What's unique about our shareable links and sharing with Pieces for Developers is that all of our users receive their own, dedicated cloud, isolated from other users.
-
-As a result, you can _personalize your cloud domain_ with a custom name, like **https://YOUR_USERNAME.pieces.cloud**. Now, when you generate and share a link, your link will include your personalized domain, so users know exactly who it came from.
-
-_View this <a target="_blank" href="{{ links.snippets.python.snippet }}">Shared Python Snippet</a> from <a target="_blank" href="{{ links.snippets.python.collection }}">python.pieces.cloud</a> in your browser. Notice this is from the custom domain, "python"._
-
-To personalize your cloud domain, open the <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers | Desktop App</a> and navigate to the settings menu.
-
-**Important Note:** Updating your personal cloud domain can take up to 15 minutes. Don't worry, we'll notify you when this is complete.

--- a/docs/features/one-click-snippet-sharing.mdx
+++ b/docs/features/one-click-snippet-sharing.mdx
@@ -11,25 +11,25 @@ Pieces snippet sharing allows you to send someone a code snippet and its context
 Effortlessly share code snippets, screenshots, and other resources with a personalized access link (e.g., _YOUR_USERNAME.pieces.cloud_), in just a few steps.
 
 ## Getting Started with Sharable Links
-_Before getting started with snippet sharing, you will need to make sure that you are [signed in](#) that way we can create space for your private cloud._
+_Before getting started with snippet sharing, you will need to make sure that you are **signed in** that way we can create space for your private cloud._
 
 <Image zoom alt={"Generating a shareable link in the Pieces desktop app"} src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHAREABLE_LINK.gif" />
 
-1. After signing in and ensuring that you are [connected to the cloud](#), go to any snippet inside the desktop application
+1. After signing in and ensuring that you are **connected to the cloud**, go to any snippet inside the desktop application
 2. Once you have the snippet selected, press the "Sharable Link" icon on the Action menu nested on the right side of your screen.
-    - [Learn how to generate a sharable link from inside our Extensions and Plugins](#)
+    - [Learn how to generate a sharable link from inside our Extensions and Plugins](/features/one-click-snippet-sharing)
 3. This will open up the "Shareable Link Drawer" that will have a few different possibilities:
     - The link should already be present if you are connect to the cloud, or a spinner will be there with a message reading "Generating your sharable link"
         - This process is normally only about 10 seconds (maximum)
-    - "Connect to cloud" will be present if your cloud connection did not complete automatically, but you can click the cloud icon to connect - [find out more about troubleshooting Cloud Connectivity](#)
+    - "Connect to cloud" will be present if your cloud connection did not complete automatically, but you can click the cloud icon to connect
     - if you are _still_ not signed in, you can do this from here and the text box will read "Connect your Account"
 
 ### Sharing as a GitHub Gist
-Sharing as a Gist is a great alternative for sharable links if you want to post the code to your [public gists,](#) so they are accessible to more people without having to send them all a link individually.
+Sharing as a Gist is a great alternative for sharable links if you want to post the code to your [public gists,](/product-highlights-and-benefits/import-gists-from-github) so they are accessible to more people without having to send them all a link individually.
 
 <Image zoom alt={"Sharing a snippet via GitHub Gist in the Pieces desktop app"} src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SHARING_GISTS.gif" />
 
-To do this, navigate to the [Sharable Link Drawer](#) mentioned above, then:
+To do this, navigate to the Sharable Link Drawer mentioned above, then:
 
 1. **Select the GitHub logo** to the right of your sharable link inside the input
     - _If you have not authenticated with GitHub **you will have to** in order to generate a Gist_
@@ -43,34 +43,34 @@ Every Gist has a _Markdown Preview_ built using our <a target="_blank" href="{{ 
 ### Claiming a Custom Domain
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/CUSTOM_SUBDOMAIN.gif" />
 
-Claiming your custom domain can be done from Pieces Desktop **only** - so be sure to [get the app](#) if you want to claim your unique domain.
+Claiming your custom domain can be done from Pieces Desktop **only** - so be sure to [get the app](/installtion-getting-started/what-am-i-installing) if you want to claim your unique domain.
 
 To claim your custom personal domain:
-1. Open up your settings by pressing ```,``` or by click your user icon (if you aren't [signed in via Google](#) you may not have one here)
+1. Open up your settings by pressing ` , ` or by click your user icon (if you aren't signed in via Google you may not have one here)
     - | would love to get some examples in here of the difference |
 2. Find "Claim your Domain" in the text box followed by .pieces.cloud
 3. Input the new unique name that you want (this will be on all of your sharable links)
     - No special characters, no uppercase letters
-    - example: powersnippets.pieces.cloud
+    - example: ` powersnippets.pieces.cloud `
 
 **Important Note:** Updating your personal cloud domain can take up to 15 minutes. Don't worry, we'll notify you when this is complete.
 
 ## Sending Someone a Saved Material
 In order to send someone a link to your shared resource, simply take the url from inside the Sharable Link Drawer and paste it into places like:
 - GChat
-- Microsoft Teams ([we have an app for that](#))
+- Microsoft Teams ([we have an app for that](/extensions-plugins/teams))
 - Text Message via IOS Messenger or Android Messenger
 
-Each link that you generate and send looks slightly different, but all will be marked by your Custom Sharable link, just like in this example from our friends at [dart-tutorial](#):
+Each link that you generate and send looks slightly different, but all will be marked by your Custom Sharable link, just like in this example from our friends at [dart-tutorial](https://dart-tutorial.com):
 
 `https://snippets.pieces.cloud/` + `?p=111d45b730`
 
 ## Saving a Shared Material you Received
 <Image zoom alt={"Saving a snippet from the Pieces Share Web App"} src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SAVE_FROM_WEB" />
 
-When you receive a sharable link from someone, you can start by `cmd` or `ctrl` clicking the link that you received or pasting it into your browser, which will open up our [Share Web App](#) that allows you to view the shared material before saving it.
+When you receive a sharable link from someone, you can start by ` cmd ` or ` ctrl ` clicking the link that you received or pasting it into your browser, which will open up our **Share Web App** that allows you to view the shared material before saving it.
 
-Once on this page, you can save the snippet to Pieces by pressing the 'Save to Pieces' button at the top of the page.
+Once on this page, you can save the snippet to Pieces by pressing the ` Save to Pieces ` button at the top of the page.
 
 You can now access and reuse the locally saved resource in the **Desktop App** or in your IDE with the <a target="_blank" href="{{ links.extensions.vscode }}">Pieces for Developers | VSCode Extension</a> or <a target="_blank" href="{{ links.extensions.jetbrains }}">Pieces for Developers | Jetbrains Plugin</a>.
 

--- a/docs/features/transforming-snippets.mdx
+++ b/docs/features/transforming-snippets.mdx
@@ -14,35 +14,22 @@ In order to access the snippet transformations, first you need to [save your fir
 1. Use ` cmd/ctrl + e `Press **Edit this snippet** which will open up the [Edit Mode View](#) and will change the icons on the Quick Action Menu
 
 2. Each of the icons here represent a different transformation style:
-    - **[Modify Snippet for Boilerplate Usage](#)
+    - **[Modify Snippet for Boilerplate Usage](#)**
         - you can transform a code snippet into a boilerplate template in seconds, complete with any notes as code comments! This makes it extremely easy to make your code even more reusable.
-    - [Modify Snippet for Improved Performance](#)
+    - **[Modify Snippet for Improved Performance](#)**
         - re-write a code snippet in its current language to be more performant
-    - [Modify Snippet to Improve Readability & Understanding](#)
-    - [Transform or Translate a Snippet with a Description](#)
+    - **[Modify Snippet to Improve Readability & Understanding](#)**
+        - Learning a new programming language? With just two clicks, you can edit your code snippets to be more human-readable. This makes it much easier to understand how a code snippet works, and is useful for developers of all experience levels.
+    - **[Transform or Translate a Snippet with a Description](#)**
         - Can turn one language into another
         - (optional) takes a description that can additionally transform the snippet
 
 3. Once you perform any of the transformations, you will have a few options on how to complete the transformations process. You choose any of the following:
     - Save and Exit
-    - Save as Duplicate
+    - Save as Duplicate (will save the original and the new transformed version)
     - Discard and Exit
     - Undo Changes
 
 4. Once you select a specific transformation on a snippet, Pieces will keep track of it and mark the transform icon with a green checkmark if you have already performed that specific transformation.
 
 _Our Transformations are currently in Beta - please <a target="_blank" href="https://getpieces.typeform.com/to/mCjBSIjF">share any feedback</a> so that we can continue to make them more useful!_
-
-## Modify for Boilerplate
-With our new feature,
-
-## Improve Readability
-Learning a new programming language? With just two clicks, you can edit your code snippets to be more human-readable. This makes it much easier to understand how a code snippet works, and is useful for developers of all experience levels.
-
-## Improve Performance
-Pieces can now re-write a code snippet in its current language to be more performant. This means better code in less time! It's a huge time-saver for you.
-
-## Transform or Translate with a Description
-Now you can convert any code snippet to a new language supported by Pieces, without any manual rewriting! This feature is incredibly useful if you work on multiple projects that use different programming languages, or if you find a solution to a problem in a language that's different from what you're looking for.
-
-After converting a code snippet, you can save it as an update to your existing snippet, or discard the changes.

--- a/docs/features/transforming-snippets.mdx
+++ b/docs/features/transforming-snippets.mdx
@@ -4,12 +4,37 @@ description: Snippets are sometimes very close to the format you need, or they w
 ---
 
 # Transforming Snippets
+
 Snippets are sometimes very close to the format you need, or they would be better utilized as boilerplate for different applications. With transformations, you can save even more time while coding. Transformations can convert languages, improve code readability and performance, and create boilerplate templates.
+
+| Quick action menu with transform icons |
+
+## Getting Started with Snippet Transformations
+In order to access the snippet transformations, first you need to [save your first code snippet](#). Once you have code inside of Pieces Desktop:
+1. Use ` cmd/ctrl + e `Press **Edit this snippet** which will open up the [Edit Mode View](#) and will change the icons on the Quick Action Menu
+
+2. Each of the icons here represent a different transformation style:
+    - **[Modify Snippet for Boilerplate Usage](#)
+        - you can transform a code snippet into a boilerplate template in seconds, complete with any notes as code comments! This makes it extremely easy to make your code even more reusable.
+    - [Modify Snippet for Improved Performance](#)
+        - re-write a code snippet in its current language to be more performant
+    - [Modify Snippet to Improve Readability & Understanding](#)
+    - [Transform or Translate a Snippet with a Description](#)
+        - Can turn one language into another
+        - (optional) takes a description that can additionally transform the snippet
+
+3. Once you perform any of the transformations, you will have a few options on how to complete the transformations process. You choose any of the following:
+    - Save and Exit
+    - Save as Duplicate
+    - Discard and Exit
+    - Undo Changes
+
+4. Once you select a specific transformation on a snippet, Pieces will keep track of it and mark the transform icon with a green checkmark if you have already performed that specific transformation.
 
 _Our Transformations are currently in Beta - please <a target="_blank" href="https://getpieces.typeform.com/to/mCjBSIjF">share any feedback</a> so that we can continue to make them more useful!_
 
-## Templatizer
-With our new feature, you can transform a code snippet into a boilerplate template in seconds, complete with any notes as code comments! This makes it extremely easy to make your code even more reusable.
+## Modify for Boilerplate
+With our new feature,
 
 ## Improve Readability
 Learning a new programming language? With just two clicks, you can edit your code snippets to be more human-readable. This makes it much easier to understand how a code snippet works, and is useful for developers of all experience levels.
@@ -17,7 +42,7 @@ Learning a new programming language? With just two clicks, you can edit your cod
 ## Improve Performance
 Pieces can now re-write a code snippet in its current language to be more performant. This means better code in less time! It's a huge time-saver for you.
 
-## Convert Language
+## Transform or Translate with a Description
 Now you can convert any code snippet to a new language supported by Pieces, without any manual rewriting! This feature is incredibly useful if you work on multiple projects that use different programming languages, or if you find a solution to a problem in a language that's different from what you're looking for.
 
 After converting a code snippet, you can save it as an update to your existing snippet, or discard the changes.

--- a/docs/features/transforming-snippets.mdx
+++ b/docs/features/transforming-snippets.mdx
@@ -3,24 +3,24 @@ title: Transforming Snippets
 description: Snippets are sometimes very close to the format you need, or they would be better utilized as boilerplate for different applications. With transformations, you can save even more time while coding. Transformations can convert languages, improve code readability and performance, and create boilerplate templates.
 ---
 
-# Transforming Snippets
+<link rel="canonical" href="https://docs.pieces.app/features/transforming-snippets" />
 
+
+# Transforming Snippets
 Snippets are sometimes very close to the format you need, or they would be better utilized as boilerplate for different applications. With transformations, you can save even more time while coding. Transformations can convert languages, improve code readability and performance, and create boilerplate templates.
 
-| Quick action menu with transform icons |
-
 ## Getting Started with Snippet Transformations
-In order to access the snippet transformations, first you need to [save your first code snippet](#). Once you have code inside of Pieces Desktop:
-1. Use ` cmd/ctrl + e `Press **Edit this snippet** which will open up the [Edit Mode View](#) and will change the icons on the Quick Action Menu
+In order to access the snippet transformations, first you need to [save your first code snippet](/product-highlights-and-benefits/saving-useful-developer-materials). Once you have code inside of Pieces Desktop:
+1. Use ` cmd/ctrl + e `Press **Edit this snippet** which will open up the [Edit Mode View](/features/auto-enrichment) and will change the icons on the Quick Action Menu
 
 2. Each of the icons here represent a different transformation style:
-    - **[Modify Snippet for Boilerplate Usage](#)**
+    - **Modify Snippet for Boilerplate Usage**
         - you can transform a code snippet into a boilerplate template in seconds, complete with any notes as code comments! This makes it extremely easy to make your code even more reusable.
-    - **[Modify Snippet for Improved Performance](#)**
+    - **Modify Snippet for Improved Performance**
         - re-write a code snippet in its current language to be more performant
-    - **[Modify Snippet to Improve Readability & Understanding](#)**
+    - **Modify Snippet to Improve Readability & Understanding**
         - Learning a new programming language? With just two clicks, you can edit your code snippets to be more human-readable. This makes it much easier to understand how a code snippet works, and is useful for developers of all experience levels.
-    - **[Transform or Translate a Snippet with a Description](#)**
+    - **Transform or Translate a Snippet with a Description**
         - Can turn one language into another
         - (optional) takes a description that can additionally transform the snippet
 

--- a/docs/global-search-suggestion-reuse/adjusting-settings-for-search.mdx
+++ b/docs/global-search-suggestion-reuse/adjusting-settings-for-search.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/global-search#adjusting-settings-for-optimal-search-results
----

--- a/docs/global-search-suggestion-reuse/global-search.mdx
+++ b/docs/global-search-suggestion-reuse/global-search.mdx
@@ -1,4 +1,0 @@
----
-redirect: https://docs.pieces.app/features/global-search
----
-

--- a/docs/global-search-suggestion-reuse/sort-scope-relevant.mdx
+++ b/docs/global-search-suggestion-reuse/sort-scope-relevant.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/global-search#sorting-by-realtime-or-scope-relevant-suggestions
----

--- a/docs/global-search-suggestion-reuse/workflow-activity-stream.mdx
+++ b/docs/global-search-suggestion-reuse/workflow-activity-stream.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/workflow-activity
----

--- a/docs/global-search-suggestion-reuse/workflow-activity.mdx
+++ b/docs/global-search-suggestion-reuse/workflow-activity.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/workflow-activity
----

--- a/docs/new-to-pieces/how-our-search-works.mdx
+++ b/docs/new-to-pieces/how-our-search-works.mdx
@@ -1,0 +1,22 @@
+## Adjust Settings for Optimal Search Results
+Pieces for Developers offers three ways to search within the Desktop App in order to quickly find what you need.
+
+### Blended Search
+- Search via multiple query matches, including code, tags, descriptions, and links. This method can be particularly useful for users who need to search for specific information across a variety of sources.
+
+### Full-Text Search
+- Search for text values within code, documents, and other text-based sources. This method is particularly useful for users who are looking for specific words or phrases.
+
+### Neural Code Search
+- Search by describing what you're looking for using natural language. This method can be particularly useful for users who are not familiar with the specific terminology used in code or who are looking for a more intuitive way to search for information.
+
+## Sorting by Realtime or Scope-Relevant Suggestions
+
+<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/SORT.gif" />
+
+The demands on developers are increasing every day. As a result, a developer's time is becoming ever more precious and anything that boosts productivity is no longer a nice-to-have, but a need-to-have.
+
+With that, our team has invested serious resources into enabling Pieces for Developers to proactively suggest the most relevant materials at the right time.
+
+### Sorting via Scope Relevant Suggestions
+We're excited to for you to check out **Sorting via Suggestions**, which is based on your recently saved materials, available in our <a target="_blank" href="{{ links.website.pfd_desktop_install }}">Flagship Desktop App</a>.

--- a/docs/personalized-link-sharing/saving-for-offline.mdx
+++ b/docs/personalized-link-sharing/saving-for-offline.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/one-click-snippet-sharing#saving-a-shared-material
----

--- a/docs/personalized-link-sharing/share-via-github-gist.mdx
+++ b/docs/personalized-link-sharing/share-via-github-gist.mdx
@@ -1,4 +1,0 @@
----
-redirect: https://docs.pieces.app/features/one-click-link-sharing#share-via-github-gist
----
-

--- a/docs/personalized-link-sharing/single-click-link-sharing.mdx
+++ b/docs/personalized-link-sharing/single-click-link-sharing.mdx
@@ -1,3 +1,0 @@
----
-redirect: https://docs.pieces.app/features/one-click-snippet-sharing
----

--- a/docs/product-highlights-and-benefits/import-gists-from-github.mdx
+++ b/docs/product-highlights-and-benefits/import-gists-from-github.mdx
@@ -11,8 +11,30 @@ description: When you import Gists, Pieces attaches metadata from the original r
 
 Import saved code from GitHub with the <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers | Desktop App</a>. When you import Gists, Pieces attaches metadata from the original repo along with PRs, related people, and additional context.
 
-## Gist Metadata
+## How to Import Gists into Pieces Desktop
+Before proceeding to import gists from GitHub into Pieces, make sure that you are signed in, and
+_if you are signed in to Google and GitHub, be sure that the **primary emails on both accounts match**._
+
+To import the Gists and upgrade them:
+1. **Press 'Add Snippets' > 'Import Gists'**
+2. The Snippet Discovery Window will open **but don't worry** we use snippet discovery to enrich your snippets as you import them from GitHub, so they do not lose their context.
+    -  [Learn more about origin details and other context](#)
+3. Once you press "Select Gists" - in a similar way as [Snippet Discovery](#), you will be presented with a list of Snippets that have been discovered from your github account.
+    - if you are not seeing you Gists, make sure they are set to public otherwise they will not be detected
+4. Select the Gists that you want by pressing the checkbox to select each on individually, or by pressing "save all" in the top right
+5. You will be brought back to your default view and then can see all the snippets that you just discovered inside your gists
+
+### Gist Metadata
 Each code snippet that you save as a Gist is packed full of metadata and information about the repository you saved it from. Traditionally when you save a Gist, its origin can be lost unless you take a lot of extra steps or click through dozens of pull requests and commits.
 
-But when you import the Gists you've already created to Pieces, metadata that was previously hidden can be found in the Information View of Pieces for Developers.
+Some of the metadata that you may get when importing gists in Pieces Desktop are:
+- related links to urls about the repo the code came from
+- commit history included inside the description of the snippet
+- resource documentation links for packages used in the config files
+- other users that are included in the comments or pull request
+
+### Where can I see this newly uncovered Data?
+If you toggle to the [information view](#) you can find all the metadata that came through from GitHub that was previously difficult to see.
+
+[Learn about the information view in depth](#)
 

--- a/docs/product-highlights-and-benefits/import-gists-from-github.mdx
+++ b/docs/product-highlights-and-benefits/import-gists-from-github.mdx
@@ -18,8 +18,8 @@ _if you are signed in to Google and GitHub, be sure that the **primary emails on
 To import the Gists and upgrade them:
 1. **Press 'Add Snippets' > 'Import Gists'**
 2. The Snippet Discovery Window will open **but don't worry** we use snippet discovery to enrich your snippets as you import them from GitHub, so they do not lose their context.
-    -  [Learn more about origin details and other context](#)
-3. Once you press "Select Gists" - in a similar way as [Snippet Discovery](#), you will be presented with a list of Snippets that have been discovered from your github account.
+    -  [Learn more about origin details and other context](/features/auto-enrichment)
+3. Once you press "Select Gists" - in a similar way as [Snippet Discovery](/product-highlights-and-benefits/in-project-snippet-discovery), you will be presented with a list of Snippets that have been discovered from your github account.
     - if you are not seeing you Gists, make sure they are set to public otherwise they will not be detected
 4. Select the Gists that you want by pressing the checkbox to select each on individually, or by pressing "save all" in the top right
 5. You will be brought back to your default view and then can see all the snippets that you just discovered inside your gists
@@ -34,7 +34,7 @@ Some of the metadata that you may get when importing gists in Pieces Desktop are
 - other users that are included in the comments or pull request
 
 ### Where can I see this newly uncovered Data?
-If you toggle to the [information view](#) you can find all the metadata that came through from GitHub that was previously difficult to see.
+If you toggle to the **Context view** you can [find all the metadata that came through from GitHub](/features/auto-enrichment) that was previously difficult to see.
 
-[Learn about the information view in depth](#)
+[Learn about the information view in depth](/features/managing-saved-materials)
 

--- a/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
+++ b/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
@@ -1,15 +1,42 @@
 ---
-title: In-Project Snippet Discovery
+title: Snippet Discovery
 description: The first developer tool in the world to ingest an entire code base and return hyper-specific, highly reusable code snippets entirely offline and on-device.
 ---
 
 <link rel="canonical" href="https://docs.pieces.app/product-highlights-and-benefits/in-project-snippet-discovery" />
 
-# In-Project Snippet Discovery
+# Snippet Discovery
 
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SNIPPET_DISCOVERY_VS_CODE_MIN" />
 
 <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a> is the first developer tool in the world to ingest an entire code base and return hyper-specific, highly reusable code snippets entirely offline and on-device.
+
+## What is Snippet Discovery?
+Snippet Discovery allows you to create code snippets from the code you have already written in a specific project, directory, or file. This automated process is useful when:
+- [Getting Started with Pieces Desktop and you have no snippets](#)
+- Onboarding into a new project and wanting to get some of the most useful snippets in the Repo
+- Forking a repository and wanting to get any reference docs mentioned or related to the project
+- and many other cases!
+
+[See more Use Cases for Snippet Discovery](#)
+
+## Running Snippet Discovery
+To run Snippet Discovery, you will need to follow these instructions here:
+1. **Press 'Add Snippets' > 'Snippet Discovery'**
+2. **Select Files**:
+    - This allows for selecting a single or multiple files. Once the [File Picker](#) opens, select a single file and press 'open' or hold ```cmd/ctrl``` while you select each file
+
+3. **Select a Folder**:
+    - When selecting a folder, you can only select one at a time. Since there is an unknown number of files it is best to select the directory closest to the code that you use
+    - For Example: instead of using a /lib/widgets or /src/views, it may be better to use the non nested /lib or /src to attach more holistic context
+
+4. **Select Gists**:
+    - Selecting Gists _requires_ you to be signed in. If you are not signed in when you select this option, you will receive a notification to sign in.
+    - We use this to connect your GitHub Account to your Pieces Account.
+        - [Learn more about Pieces GitHub and Gists](#)
+
+5. **Drag and Drop**:
+ - When you drag code into Pieces Desktop while on the list or gallery view, it will be added as a single asset. **But if you drag an entire file or directory into Pieces Desktop while Snippet Discovery is open, it will perform snippet discovery on the file or directory you just added.**
 
 ## Why should you run Snippet Discovery?
 Running **Snippet Discovery** on a local source repository has huge benefits:

--- a/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
+++ b/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
@@ -13,27 +13,27 @@ description: The first developer tool in the world to ingest an entire code base
 
 ## What is Snippet Discovery?
 Snippet Discovery allows you to create code snippets from the code you have already written in a specific project, directory, or file. This automated process is useful when:
-- [Getting Started with Pieces Desktop and you have no snippets](#)
-- Onboarding into a new project and wanting to get some of the most useful snippets in the Repo
-- Forking a repository and wanting to get any reference docs mentioned or related to the project
+- **Getting Started with Pieces Desktop and you have no snippets**
+- **Onboarding into a new project** and wanting to get some of the most useful snippets in the Repo
+- Forking a repository and wanting any reference docs mentioned or related to the project
 - and many other cases!
 
-[See more Use Cases for Snippet Discovery](#)
+[//]: # ([See more Use Cases for Snippet Discovery]&#40;#&#41;)
 
 ## Running Snippet Discovery
 To run Snippet Discovery, you will need to follow these instructions here:
-1. **Press 'Add Snippets' > 'Snippet Discovery'**
+1. **Press _Add Snippets_ > _Snippet Discovery_**
 2. **Select Files**:
-    - This allows for selecting a single or multiple files. Once the [File Picker](#) opens, select a single file and press 'open' or hold ```cmd/ctrl``` while you select each file
+    - This allows for selecting a single or multiple files. Once the [File Picker](product-highlights-and-benefits/saving-useful-developer-materials#pieces-desktop) opens, select a single file and press 'open' or hold ``` cmd/ctrl ``` while you select multiple files
 
 3. **Select a Folder**:
     - When selecting a folder, you can only select one at a time. Since there is an unknown number of files it is best to select the directory closest to the code that you use
-    - For Example: instead of using a /lib/widgets or /src/views, it may be better to use the non nested /lib or /src to attach more holistic context
+    - For Example: instead of using a ` /lib/widgets ` or ` /src/views `, it may be better to use the non nested ` /lib ` or ` /src ` to attach more holistic context
 
 4. **Select Gists**:
     - Selecting Gists _requires_ you to be signed in. If you are not signed in when you select this option, you will receive a notification to sign in.
     - We use this to connect your GitHub Account to your Pieces Account.
-        - [Learn more about Pieces GitHub and Gists](#)
+        - [Learn more about Pieces GitHub and Gists](/product-highlights-and-benefits/import-gists-from-github)
 
 5. **Drag and Drop**:
  - When you drag code into Pieces Desktop while on the list or gallery view, it will be added as a single asset. **But if you drag an entire file or directory into Pieces Desktop while Snippet Discovery is open, it will perform snippet discovery on the file or directory you just added.**

--- a/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
+++ b/docs/product-highlights-and-benefits/in-project-snippet-discovery.mdx
@@ -7,7 +7,7 @@ description: The first developer tool in the world to ingest an entire code base
 
 # Snippet Discovery
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SNIPPET_DISCOVERY_VS_CODE_MIN" />
+<Image alt={"Using Snippet Discovery in the Pieces for Developers desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/SNIPPET_DISCOVERY_VS_CODE_MIN" />
 
 <a target="_blank" href="https://docs.pieces.app/overview">Pieces for Developers</a> is the first developer tool in the world to ingest an entire code base and return hyper-specific, highly reusable code snippets entirely offline and on-device.
 

--- a/docs/product-highlights-and-benefits/saving-screenshots.mdx
+++ b/docs/product-highlights-and-benefits/saving-screenshots.mdx
@@ -9,7 +9,33 @@ description: By saving media to the Pieces for Developers Desktop app, all of yo
 
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_resource_center/CODE_FROM_SCREENSHOT.gif" />
 
-To save an image or screenshot, you can either drag the image directly into the <a target="_blank" href="https://docs.pieces.app/overview">Flagship Desktop App</a> window, or you can _upload a file_ by clicking the "Add +" button above the icons in the carousel.
+## Why Would I need a Screenshot of Code?
+Sometimes the code you need is not in a location where it can be copied, - like youtube videos, tutorials, onboarding docs, or messages. **You can capture this code, modify and manipulate it as you wish** by taking a screenshot using ```cmd+shift+4``` or ```windows-key+shift+S```.
 
-## No more retyping the code from screenshots!
-Once you've added a screenshot of code to Pieces for Developers, our code-specific Optical Character Recognition (OCR) engine extracts the code from your images so that it's easily copyable and editable.
+### Adding A Screenshot Via "Add a File"
+
+You can quickly add a Screenshot using the File Picker by pressing ```cmd+U``` or ```ctrl+U``` which will bring up the Native File Browser Window Based on your OS.
+
+To add an image from a specific file location, you can follow these steps:
+- Press "+ Add Snippets" to open the [Add Code Snippets & Developer Material Layouts](#) Dialog
+- Select "Add a file"
+- Once the File Picker opens, you can select an image file, and it will be added to as a resource to Pieces Desktop and any extensions or plugins you have installed.
+
+Note: You can drag the image directly from
+- macOS quick preview of a screenshot that appears in the bottom corner
+- [Windows Snipping Tool Preview](https://support.microsoft.com/en-us/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b) attaches the code block to your clipboard, or you can click the screenshot and select the copy button to copy and paste the snippet into Pieces Desktop.
+
+### Getting Code Out of a Screenshot
+To get the code out of a screenshot, all you have to do is press the ```{ }``` icon that is located in the Action Menu on the right side of the application.
+
+This will show you a few things:
+- First, you now can edit the code snippet if there are any inconsistencies (but don't worry our ML Team doubts you'll get them)
+- You can see related links, tags, and other data that was pulled from the code inside the image.
+[Learn about Enrichment, Metadata, and more](#)
+
+
+
+
+
+
+

--- a/docs/product-highlights-and-benefits/saving-screenshots.mdx
+++ b/docs/product-highlights-and-benefits/saving-screenshots.mdx
@@ -7,18 +7,18 @@ description: By saving media to the Pieces for Developers Desktop app, all of yo
 
 # Saving Screenshots and Optical Code Recognition
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_resource_center/CODE_FROM_SCREENSHOT.gif" />
+<Image alt={"Dragging a screenshot to Pieces and then extracting the code via OCR."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_resource_center/CODE_FROM_SCREENSHOT.gif" />
 
 ## Why Would I need a Screenshot of Code?
-Sometimes the code you need is not in a location where it can be copied, - like youtube videos, tutorials, onboarding docs, or messages. **You can capture this code, modify and manipulate it as you wish** by taking a screenshot using ```cmd+shift+4``` or ```windows-key+shift+S```.
+Sometimes the code you need is not in a location where it can be copied, - like youtube videos, tutorials, onboarding docs, or messages. **You can capture this code, modify and manipulate it as you wish** by taking a screenshot using ``` cmd + shift + 4 ``` or ``` windowskey + shift + S ```.
 
 ### Adding A Screenshot Via "Add a File"
 
-You can quickly add a Screenshot using the File Picker by pressing ```cmd+U``` or ```ctrl+U``` which will bring up the Native File Browser Window Based on your OS.
+You can quickly add a Screenshot using the File Picker by pressing ``` cmd + u ``` or ``` ctrl + U ``` which will bring up the Native File Browser Window Based on your OS.
 
 To add an image from a specific file location, you can follow these steps:
-- Press "+ Add Snippets" to open the [Add Code Snippets & Developer Material Layouts](#) Dialog
-- Select "Add a file"
+- **Press _+ Add Snippets_** to open the [Add Code Snippets & Developer Material Layouts](/product-highlights-and-benefits/saving-useful-developer-materials) Dialog
+- Select **Add a file**
 - Once the File Picker opens, you can select an image file, and it will be added to as a resource to Pieces Desktop and any extensions or plugins you have installed.
 
 Note: You can drag the image directly from
@@ -26,12 +26,13 @@ Note: You can drag the image directly from
 - [Windows Snipping Tool Preview](https://support.microsoft.com/en-us/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b) attaches the code block to your clipboard, or you can click the screenshot and select the copy button to copy and paste the snippet into Pieces Desktop.
 
 ### Getting Code Out of a Screenshot
-To get the code out of a screenshot, all you have to do is press the ```{ }``` icon that is located in the Action Menu on the right side of the application.
+To get the code out of a screenshot, all you have to do is press the ``` { } ``` icon that is located in the Action Menu on the right side of the application.
 
 This will show you a few things:
 - First, you now can edit the code snippet if there are any inconsistencies (but don't worry our ML Team doubts you'll get them)
 - You can see related links, tags, and other data that was pulled from the code inside the image.
-[Learn about Enrichment, Metadata, and more](#)
+
+[Learn about Enrichment, Metadata, and more](/features/auto-enrichment)
 
 
 

--- a/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
+++ b/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
@@ -7,13 +7,13 @@ description:  Drag images, files, and more directly into the Pieces for Develope
 
 # Save Useful Developer Materials
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DROP_A_FILE.gif" />
+<Image alt={"Saving a snippet to the Pieces desktop app."} zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DROP_A_FILE.gif" />
 
 You can **save** a number of developer materials into Pieces for Developers, all by dragging, via right click, file picker, and even cool features like auto-save.
 
 Here's our list of Supported Materials:
-- Images (.png, .jpeg, .jpg, and [more](#) )
-    - [Learn more about Importing Screenshots](/product-highlights-and-benifits/saving-screenshots)
+- Images (.png, .jpeg, .jpg, .gif)
+    - [Learn more about Importing Screenshots](/product-highlights-and-benefits/saving-screenshots)
 - Raw Text or Code
 - Whole Files
     - (if you want to import a directory and use Snippet Discovery, Pieces will discover Materials for you)
@@ -21,7 +21,7 @@ Here's our list of Supported Materials:
 - Are there More?
 
 ## Ways to Add Materials to Pieces
-When using Pieces for Developers - whether it be inside the Desktop App or one of our Plugins (See the [Microsoft Teams App](#)) - there are lots of ways to save Developer Materials. They can be seperated into _Universal_ and _Specific_ as follows:
+When using Pieces for Developers - whether it be inside the Desktop App or one of our Plugins (See the [Microsoft Teams App](/extensions-plugins/teams)) - there are lots of ways to save Developer Materials. They can be seperated into _Universal_ and _Specific_ as follows:
 
 ### Universal:
 - Right click and select "Save to Pieces" in your context menu, the snippet will be added with metadata to Pieces Desktop
@@ -32,23 +32,24 @@ When using Pieces for Developers - whether it be inside the Desktop App or one o
 #### Pieces Desktop:
 - Drag & Drop a file or Image over top of Pieces Desktop to save the contents as a new resource
 
-- Via [Snippet Discovery](#)
+- Via [Snippet Discovery](/product-highlights-and-benefits/in-project-snippet-discovery)
 
 #### Jetbrains Plugin:
 - Drag Code Directly into Pieces for JetBrains in the sidebar and a resource will be created
-- Use ```option+shift+P``` or ```alt+shift+P``` with code selected to save a new resource
-[Learn more about Saving in the JetBrains Plugin](#)
+- Use ``` option + shift + P ``` or ``` alt + shift + P ``` with code selected to save a new resource
+[Learn more about Saving in the JetBrains Plugin](/extensions-plugins/jetbrains)
 
 #### VSCode Extension:
-- Use ```command+shift+V``` or ```windows key+shift+V``` with code selected to save a new resource
-[Learn more about Saving in the VSCode Extension](#)
+- Use ``` command + shift + V ``` or ``` windowskey + shift + V ``` with code selected to save a new resource
+[Learn more about saving in the Pieces VSCode extension](/extensions-plugins/vscode)
 
 #### Chrome Extension:
-- Press the 'Copy & Save' button that appears when you hover any code block
-    - Our code block detection inside of Pieces Chrome Extension depends on the html style of the codeblocks on the page. We detect ```<pre>``` tags and ```<code>``` tags to capture code and insert buttons to save and share
-    - Learn more about [Sharing and the Share button](#) that appears next to 'Copy & Save'
-- Use ```cmd+shift+s``` to save text or code from a website
-[Learn more about Saving in the Chrome Extension](#)
+- Press the **Copy & Save** button that appears when you hover any code block
+    - Our code block detection inside of Pieces Chrome Extension depends on the html style of the codeblocks on the page. We detect ``` <pre> ``` tags and ``` <code> ``` tags to capture code and insert buttons to save and share
+    - Learn more about [Sharing and the Share button](/features/one-click-snippet-sharing) that appears next to 'Copy & Save'
+- Use ``` cmd/ctrl + shift + S ``` to save text or code from a website
+
+[Learn more about Saving in the Chrome Extension](/extensions-plugins/chrome)
 
 ## Stay in Flow with Effortless Save
 We are making a continuous effort to provide our users with frictionless ways to save key workflow materials. Stay in flow with our <a target="_blank" href="https://docs.pieces.app/overview">Flagship Desktop App</a> and simply copy a code snippet or other resource and paste it into Pieces. You can also drag images, files, and more directly into the desktop app. Save all types of resources. It's better to have a resource and not need it than to need it and not have it!

--- a/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
+++ b/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
@@ -9,20 +9,60 @@ description:  Drag images, files, and more directly into the Pieces for Develope
 
 <Image zoom src="https://storage.googleapis.com/pieces_static_resources/pfd_wiki/DROP_A_FILE.gif" />
 
-Pieces for Developers was built from the ground up to serve as a centralized place to save all types of materials and resources related to a developer's work-in-progress journey.
-Code snippets, scratch files, screenshots, UML diagrams, links, and more. Paste something from your clipboard, drag & drop, or save it directly in IDE via our plugins.
+You can **save** a number of developer materials into Pieces for Developers, all by dragging, via right click, file picker, and even cool features like auto-save.
 
-<Image zoom src="https://storage.googleapis.com/pieces_static_resources/vs_code_marketplace/GIFs/MATERIAL_TYPES" />
+Here's our list of Supported Materials:
+- Images (.png, .jpeg, .jpg, and [more](#) )
+    - [Learn more about Importing Screenshots](#)
+- Raw Text or Code
+- Whole Files
+    - (if you want to import a directory and use Snippet Discovery, Pieces will discover Materials for you)
+- GitHub Gists, imported through Snippet Discovery
+- Are there More?
+
+## Ways to Add Materials to Pieces
+When using Pieces for Developers - whether it be inside the Desktop App or one of our Plugins (See the [Microsoft Teams App](#)) - there are lots of ways to save Developer Materials. They can be seperated into _Universal_ and _Specific_ as follows:
+
+### Universal:
+- Right click and select "Save to Pieces" in your context menu, the snippet will be added with metadata to Pieces Desktop
+
+### Specific:
+
+#### Pieces Desktop:
+- Drag & Drop a file or Image over top of Pieces Desktop to save the contents as a new resource
+- Via Snippet Discovery
+    1. **Press 'Add Snippets' > 'Snippet Discovery'**
+    2. **Select Files**:
+        - This allows for selecting a single or multiple files. Once the [File Picker](#) opens, select a single file and press 'open' or hold ```cmd/ctrl``` while you select each file
+    3. **Select a Folder**:
+        - When selecting a folder, you can only select one at a time. Since there is an unknown number of files it is best to select the directory closest to the code that you use
+        - For Example: instead of using a /lib/widgets or /src/views, it may be better to use the non nested /lib or /src to attach more holistic context
+    4. **Select Gists**:
+        - Selecting Gists _requires_ you to be signed in. If you are not signed in when you select this option, you will receive a notification to sign in.
+            - We use this to connect your GitHub Account to your Pieces Account.
+        - [Learn more about Pieces GitHub and Gists](#)
+    5. **Drag and Drop**:
+        - When you drag code into Pieces Desktop while on the list or gallery view, it will be added as a single asset. **But if you drag an entire file or directory into Pieces Desktop while Snippet Discovery is open, it will perform snippet discovery on the file or directory you just added.**
+
+#### Jetbrains Plugin:
+- Drag Code Directly into Pieces for JetBrains in the sidebar and a resource will be created
+- Use ```option+shift+P``` or ```alt+shift+P``` with code selected to save a new resource
+[Learn more about Saving in the JetBrains Plugin](#)
+
+#### VSCode Extension:
+- Use ```command+shift+V``` or ```windows key+shift+V``` with code selected to save a new resource
+[Learn more about Saving in the VSCode Extension](#)
+
+#### Chrome Extension:
+- Press the 'Copy & Save' button that appears when you hover any code block
+    - Our code block detection inside of Pieces Chrome Extension depends on the html style of the codeblocks on the page. We detect ```<pre>``` tags and ```<code>``` tags to capture code and insert buttons to save and share
+    - Learn more about [Sharing and the Share button](#) that appears next to 'Copy & Save'
+- Use ```cmd+shift+s``` to save text or code from a website
+[Learn more about Saving in the Chrome Extension](#)
 
 ## Stay in Flow with Effortless Save
 We are making a continuous effort to provide our users with frictionless ways to save key workflow materials. Stay in flow with our <a target="_blank" href="https://docs.pieces.app/overview">Flagship Desktop App</a> and simply copy a code snippet or other resource and paste it into Pieces. You can also drag images, files, and more directly into the desktop app. Save all types of resources. It's better to have a resource and not need it than to need it and not have it!
 
 > Boilerplate/Reference Snippets, Common Bash/Powershell Commands, CI/CD Configurations, HTTP Requests, Screenshots, Architecture/UML Diagrams, Text Notes, and so much more.
 
-### Images & Screenshots
-To save an image or screenshot, you can either drag the image directly into the <a target="_blank" href="https://docs.pieces.app/overview">Flagship Desktop App</a> window, or you can _upload a file_ by clicking the "Add +" button above the icons in the carousel.
 
-### Files & Folders
-Any file type that Pieces for Developers supports can be dragged or copied into the desktop app. Simply drag the file over the Pieces Desktop App and a green plus will appear. Drop the file into the application window; it will be added to the repo immediately.
-
-If your file is too large, you can compress the image via the notification that appears when you release your mouse click.

--- a/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
+++ b/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
@@ -13,7 +13,7 @@ You can **save** a number of developer materials into Pieces for Developers, all
 
 Here's our list of Supported Materials:
 - Images (.png, .jpeg, .jpg, and [more](#) )
-    - [Learn more about Importing Screenshots](#)
+    - [Learn more about Importing Screenshots](/product-highlights-and-benifits/saving-screenshots)
 - Raw Text or Code
 - Whole Files
     - (if you want to import a directory and use Snippet Discovery, Pieces will discover Materials for you)
@@ -25,11 +25,13 @@ When using Pieces for Developers - whether it be inside the Desktop App or one o
 
 ### Universal:
 - Right click and select "Save to Pieces" in your context menu, the snippet will be added with metadata to Pieces Desktop
+- Press Paste (` cmd/ctrl + v `) after clicking anywhere inside the application window
 
 ### Specific:
 
 #### Pieces Desktop:
 - Drag & Drop a file or Image over top of Pieces Desktop to save the contents as a new resource
+
 - Via [Snippet Discovery](#)
 
 #### Jetbrains Plugin:

--- a/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
+++ b/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
@@ -30,19 +30,7 @@ When using Pieces for Developers - whether it be inside the Desktop App or one o
 
 #### Pieces Desktop:
 - Drag & Drop a file or Image over top of Pieces Desktop to save the contents as a new resource
-- Via Snippet Discovery
-    1. **Press 'Add Snippets' > 'Snippet Discovery'**
-    2. **Select Files**:
-        - This allows for selecting a single or multiple files. Once the [File Picker](#) opens, select a single file and press 'open' or hold ```cmd/ctrl``` while you select each file
-    3. **Select a Folder**:
-        - When selecting a folder, you can only select one at a time. Since there is an unknown number of files it is best to select the directory closest to the code that you use
-        - For Example: instead of using a /lib/widgets or /src/views, it may be better to use the non nested /lib or /src to attach more holistic context
-    4. **Select Gists**:
-        - Selecting Gists _requires_ you to be signed in. If you are not signed in when you select this option, you will receive a notification to sign in.
-            - We use this to connect your GitHub Account to your Pieces Account.
-        - [Learn more about Pieces GitHub and Gists](#)
-    5. **Drag and Drop**:
-        - When you drag code into Pieces Desktop while on the list or gallery view, it will be added as a single asset. **But if you drag an entire file or directory into Pieces Desktop while Snippet Discovery is open, it will perform snippet discovery on the file or directory you just added.**
+- Via [Snippet Discovery](#)
 
 #### Jetbrains Plugin:
 - Drag Code Directly into Pieces for JetBrains in the sidebar and a resource will be created

--- a/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
+++ b/docs/product-highlights-and-benefits/saving-useful-developer-materials.mdx
@@ -21,7 +21,7 @@ Here's our list of Supported Materials:
 - Are there More?
 
 ## Ways to Add Materials to Pieces
-When using Pieces for Developers - whether it be inside the Desktop App or one of our Plugins (See the [Microsoft Teams App](/extensions-plugins/teams)) - there are lots of ways to save Developer Materials. They can be seperated into _Universal_ and _Specific_ as follows:
+When using Pieces for Developers - whether it be inside the Desktop App or one of our Plugins (See an example with our [Microsoft Teams App](/extensions-plugins/teams)) - there are lots of ways to save Developer Materials. They can be seperated into _Universal_ and _Specific_ as follows:
 
 ### Universal:
 - Right click and select "Save to Pieces" in your context menu, the snippet will be added with metadata to Pieces Desktop
@@ -31,16 +31,18 @@ When using Pieces for Developers - whether it be inside the Desktop App or one o
 
 #### Pieces Desktop:
 - Drag & Drop a file or Image over top of Pieces Desktop to save the contents as a new resource
-
+- Open the file picker with ` cmd/ctrl + u `, then select the file that you would like to add
 - Via [Snippet Discovery](/product-highlights-and-benefits/in-project-snippet-discovery)
 
 #### Jetbrains Plugin:
 - Drag Code Directly into Pieces for JetBrains in the sidebar and a resource will be created
 - Use ``` option + shift + P ``` or ``` alt + shift + P ``` with code selected to save a new resource
+
 [Learn more about Saving in the JetBrains Plugin](/extensions-plugins/jetbrains)
 
 #### VSCode Extension:
 - Use ``` command + shift + V ``` or ``` windowskey + shift + V ``` with code selected to save a new resource
+
 [Learn more about saving in the Pieces VSCode extension](/extensions-plugins/vscode)
 
 #### Chrome Extension:


### PR DESCRIPTION
Here is the doc with the copy + idea work from @wes-at-pieces and @georgia-at-pieces, latest is **Second Pass Complete**: 

https://drive.google.com/drive/u/0/folders/171W8hcCFFavmPo2FGqif-ki_kr5CRslh

Running List Here with Details:

**Copy Upgrades (Existing Pages - Still Need to Double Check Georgias Upgrades):**
- [x] Saving Developer Materials 
- [x] Saving Screenshots [OCR]
- [x] Import Gists from Github
- [x] In-Project Snippet Discovery
- [x] Privacy & Security 
- [x] Auto Enrichment
- [x] Code Completion
- [x] Code Generation
- [x] Global Search 
- [x] Material Storage & Management
- [x] One Click Sharing
- [x] Snippet Transformations
- [x] Workflow Activity

New Pages that need Created, but likely will be folded into a separate pr following this one: 
- [ ] All About Our Search
- [ ] New To Pieces?
- [ ] Glossary Page 
- [ ] Troubleshooting Cloud connectivity
- [ ] The Share Web App 
- [ ] Managing User Setting 
- [ ] (Use Case) Identifying a snippets purpose 