### PR TITLE
Testing Insights for Algolia Search 

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,8 @@
   "docsearch": {
     "appId": "KTOXFODR65",
     "apiKey": "79c81e52460257d3761ea38438e29637",
-    "indexName": "pieces"
+    "indexName": "pieces",
+    "insights": true
   },
   "anchors": [
     {


### PR DESCRIPTION
Just need to add a flag but concerned since this API info is not added into the docs.page site concerning insights but in the past a number of nonspecific settings that hold true in the base tools that docs.page system is built on, you can normally pass in what i am calling "generally accepted values" based on the 3rd parties documentation.

This is important for working on this repo as there are some cases where you can get around the lack of documentation by trying things like above, or where when you try and bypass the docs.page documentation it will crash the whole site and cause it to loose rendering. 

For example : 

Insights
-  [mentioned inside of the algolia search configuration](https://docsearch.algolia.com/docs/DocSearch-v3#sending-events) that you can set `insights: true` in the configuration json file
- not mentioned on the docs.page [documentation on how to add algolia](https://use.docs.page/search) to the site.

Just want to get this info out there while we are continuing to use and improve the docs site.