### PR TITLE
Update linux.mdx

### DIFF
--- a/docs/installation-getting-started/linux.mdx
+++ b/docs/installation-getting-started/linux.mdx
@@ -96,7 +96,7 @@ To run Pieces for Developers on Linux, be sure to download both of the applicati
 
 3. Install the Pieces Desktop Snap:
     ```shell
-    $ sudo snap install pieces-for-developers
+    sudo snap install pieces-for-developers
     ```
     [Save to Pieces](https://snippets.pieces.cloud/?p=f23c48bd96)
 


### PR DESCRIPTION
Removed '$' in point 3 of linux installation command. Copying command also copies this $ symbol which gives error while running it