### PR TITLE
added instructions for brew install

### DIFF
--- a/docs/installation-getting-started/macos.mdx
+++ b/docs/installation-getting-started/macos.mdx
@@ -92,6 +92,17 @@ export const Spacer = props => {
 
     - Pieces for Developers DMG ARM64 (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/dmg-arm64/download)
 
+
+    Note: You can also install Pieces via Homebrew. 
+    1. Ensure you have [installed](https://docs.brew.sh/Installation) Homebrew in your system
+    2. Run the following command in your terminal to Install the Pieces brew package
+    ```shell
+    brew install --cask pieces
+    ```
+    [Save to Pieces](https://snippets.pieces.cloud/?p=f23c48bd96)
+    3. The above command will install the Pieces-OS cask as well. Once the package is install successfully, you can start to run Pieces OS and the Pieces for Developers application. 
+
+
 </Accordion>
 
 ## Steps to Install


### PR DESCRIPTION

We recently added an integration to be able to install Pieces via Homebrew. It should be added in the docs.


https://formulae.brew.sh/cask/pieces#default


Added in the alternative installation section 