### PR TITLE
chore: fix hotkey

### DIFF
--- a/docs/extensions-plugins/vscode.mdx
+++ b/docs/extensions-plugins/vscode.mdx
@@ -147,7 +147,7 @@ Editing a snippet that is saved to Pieces for Developers from VS Code is easy! T
 To search for a snippet:
 
 1. Open an editable file in VS Code
-2. Right-click and choose "Search Pieces" or use the shortcut ```CTRL + K``` or ```⌘ + K```
+2. Right-click and choose "Search Pieces" or use the shortcut ```CTRL + ALT + P``` or ```⌘ + ⌥ + P```
 3. Type keywords into the search bar, and when you hit enter, the snippet will be inserted into the file
 
 ## Pieces for Developers VS Code Extension Settings


### PR DESCRIPTION
fixes the vscode search hotkey from command + k to command + option + p