### PR TITLE
updates for jcef - typos: AA -> a and ending statement on android studio

### DIFF
--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -209,7 +209,7 @@ It’s important to know that the latest stable release of Android Studio (Hedge
 In order to switch your runtime:
 1. Use `⌘ + ⇧ + A` (on macOS) or `Ctrl + ⇧ + A` (Windows/Linux) shortcut to invoke action search dialog
 2. Start typing "Choose Boot Java Runtime for the IDE…”
-3. Select the latest version with annotation ending with „with JCEF”.S
+3. Select the latest version with annotation ending with "JCEF”.
 4. When you click OK and restart your IDE, **Copilot should start working properly**.
 
 ### I can't find the Pieces JetBrains Plugin in the JetBrains Marketplace!

--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -208,8 +208,8 @@ It’s important to know that the latest stable release of Android Studio (Hedge
 
 In order to switch your runtime:
 1. Use `⌘ + ⇧ + A` (on macOS) or `Ctrl + ⇧ + A` (Windows/Linux) shortcut to invoke action search dialog
-2. Start typing "Choose Boot Java Runtime for the IDE…”S
-3. Select the latest version with annotation ending with „with JCEF”.
+2. Start typing "Choose Boot Java Runtime for the IDE…”
+3. Select the latest version with annotation ending with „with JCEF”.S
 4. When you click OK and restart your IDE, **Copilot should start working properly**.
 
 ### I can't find the Pieces JetBrains Plugin in the JetBrains Marketplace!

--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -198,17 +198,18 @@ The Pieces JetBrains Plugin will automatically update when a new version is avai
 ## Troubleshooting
 
 ### Pieces Copilot: Enabling JCEF Runtime and Downgrade
-Pieces Copilot relies on JCEF, a very important component of JetBrains Runtime bundled with your IDE. By default, Android Studio is launched with AA runtime version that does not support JCEF.
+Pieces Copilot relies on JCEF, a very important component of JetBrains Runtime bundled with your IDE. By default, Android Studio is launched with a runtime version that does not support JCEF.
 
 Switch your Java runtime to JCEF enabled runtime inside your global IDE settings.
 
 > Note that this operation will require a restart of your IDE, so it’s always worth saving your work before doing this.
 
-It’s important to know that the latest stable release of Android Studio (Hedgehog 2023.1.1) unfortunately won’t benefit from this workaround, and it may throw errors regarding GPU processes restarting too many times. If you are using Android Studio Hedgehog, please consider downgrading to the second latest stable release, in this case Giraffe 2022.3.1 Patch 4.
+It’s important to know that the latest stable release of Android Studio (Hedgehog 2023.1.1) unfortunately won’t benefit from this workaround, and it may throw errors regarding GPU processes restarting too many times. If you are using Android Studio Hedgehog, please consider downgrading to the second-latest stable release, in this case Giraffe 2022.3.1 Patch 4 **until the issue is patched in Android Studio**.
+.
 
 In order to switch your runtime:
-1. Use ⌘⇧A shortcut to invoke action search dialog
-2. Start typing "Choose Boot Java Runtime for the IDE…”
+1. Use `⌘ + ⇧ + A` (on macOS) or `Ctrl + ⇧ + A` (Windows/Linux) shortcut to invoke action search dialog
+2. Start typing "Choose Boot Java Runtime for the IDE…”S
 3. Select the latest version with annotation ending with „with JCEF”.
 4. When you click OK and restart your IDE, **Copilot should start working properly**.
 

--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -205,7 +205,6 @@ Switch your Java runtime to JCEF enabled runtime inside your global IDE settings
 > Note that this operation will require a restart of your IDE, so it’s always worth saving your work before doing this.
 
 It’s important to know that the latest stable release of Android Studio (Hedgehog 2023.1.1) unfortunately won’t benefit from this workaround, and it may throw errors regarding GPU processes restarting too many times. If you are using Android Studio Hedgehog, please consider downgrading to the second-latest stable release, in this case Giraffe 2022.3.1 Patch 4 **until the issue is patched in Android Studio**.
-.
 
 In order to switch your runtime:
 1. Use `⌘ + ⇧ + A` (on macOS) or `Ctrl + ⇧ + A` (Windows/Linux) shortcut to invoke action search dialog


### PR DESCRIPTION
quick patch to correct some errors from the last PR #204 