### PR TITLE
chore: revert jlab warning

### DIFF
--- a/docs/extensions-plugins/jupyterlab.mdx
+++ b/docs/extensions-plugins/jupyterlab.mdx
@@ -41,14 +41,6 @@ export const InstallButton = props => {
   </a>
 }
 
-export const MiniSpacer = props => {
-    return <div style={{ height: "16px"}}></div>
-};
-
-<Warning>Known Installation Issues: The latest version of the extension does not currently install correctly. Please use `pip install jupyter-pieces==1.8.1` instead</Warning>
-
-<MiniSpacer></MiniSpacer>
-
 # Your Guide to Getting Started with the Pieces for JupyterLab Extension
 
 <ReleasePill src={"https://code.pieces.app/updates/improved-pieces-copilot-experiences"}>Compatible with JupyterLab 4.0.0 and higher and is currently in Beta</ReleasePill>
@@ -62,7 +54,7 @@ _The <a target="_blank" href="{{ links.website.pfd_desktop_install }}">Pieces Su
 
 1. Run this command:
     ```sh
-    pip install jupyter-pieces==1.8.1
+    pip install jupyter-pieces
     ```
 2. *(optional)* Be sure to have extensions enabled. [Read about enabling extensions.](https://tljh.jupyter.org/en/latest/howto/admin/enable-extensions.html)
 


### PR DESCRIPTION
removes the 'installation issues' section from the jupyterlab plugin