### PR TITLE
Update minimum supported macOS Monterey version

### DIFF
--- a/docs/installation-getting-started/macos.mdx
+++ b/docs/installation-getting-started/macos.mdx
@@ -61,7 +61,7 @@ export const Spacer = props => {
 }
 
 # Getting Started with Pieces for Developers on macOS
-<ReleasePill>Compatible with macOS 11 Big Sur or higher</ReleasePill>
+<ReleasePill>Compatible with macOS 12.0 Monterey or higher</ReleasePill>
 
 ![Robots installing Pieces for Developers on macOS.](/assets/installation/robots_macos.png)
 


### PR DESCRIPTION
Updating the minimum monterey version from 11 -> 12.0 and was testing something around pathing for the name of branches. 