### PR TITLE
Update pieces-copilot.mdx

### DIFF
--- a/docs/features/pieces-copilot.mdx
+++ b/docs/features/pieces-copilot.mdx
@@ -114,8 +114,10 @@ Our Copilot also comes with multiple different LLM runtimes, cloud and local in 
 
 #### Local Runtimes
 <Info>*Local LLMs come with some hefty hardware requirements, please make sure your system can fulfill them before attempting to load one of these models.*</Info>
-- Llama2, a model trained by Meta AI optimized for completing general tasks, also available in a CPU and GPU runtime.
-    - *These models require 5.6GB of RAM and 5.6GB of VRAM for the cpu and gpu runtimes respectively.*
+- Llama2 7B, a model trained by Meta AI optimized for completing general tasks, also available in a CPU and GPU runtime.
+    - *Requires a mminimum of 5.6GB RAM for the CPU model and 5.6GB of VRAM for the GPU-accelerated model.*
+- Mistral 7B, a dense Transformer, fast-deployed and fine-tuned on code datasets. Small, yet powerful for a variety of use cases. Outperforms Llama 2 13B and 34B on most benchmarks.
+    - *Requires a minimum of 6GB RAM for the CPU model and 6GB of VRAM for the GPU-accelerated model.*
 
 ## Plugin Integrations
 
@@ -128,7 +130,7 @@ Our VS Code, Jetbrains, Web Extension, Obsidian, and Jupyter Lab integrations al
 <Image zoom src="https://storage.googleapis.com/pieces_multimedia/PROMOTIONAL/PIECES_FOR_DEVELOPERS/VS_CODE/MACOS/COPILOT_CONTEXT_GENERIC/16X9/PIECES_FOR_DEVELOPERS-VS_CODE-COPILOT_CONTEXT_GENERIC-MACOS-16X9-1_10_2024.GIF" />
 
 2. **Select multiple different LLM runtimes, including local LLMs for offline, airgapped security**
- - We have an extensive list of LLMs to choose from depending on your use case including GPT-3.5, GPT-3.5 16k, GPT-4, Gemini as well as local LLMs like Llama2 (Mistral coming soon).
+ - We have an extensive list of LLMs to choose from depending on your use case including GPT-3.5, GPT-3.5 16k, GPT-4, PaLM 2 and Gemini, as well as local LLMs such as Llama2 and Mistral (CodeLlama and TinyLlama coming soon).
 
 <Image zoom src="https://storage.googleapis.com/pieces_multimedia/PROMOTIONAL/PIECES_FOR_DEVELOPERS/VS_CODE/MACOS/COPILOT/16X9/2.select-llm-runtime.gif" />
 

--- a/docs/features/pieces-copilot.mdx
+++ b/docs/features/pieces-copilot.mdx
@@ -162,4 +162,4 @@ Our VS Code, Jetbrains, Web Extension, Obsidian, and Jupyter Lab integrations al
 8. **Quickly link back to relevant files**
  - If the copilot used a file as relevant context, it will show it in the chat window, and you can click on it to view it.
 
-<Image zoom src="https://storage.googleapis.com/pieces_multimedia/PROMOTIONAL/PIECES_FOR_DEVELOPERS/VS_CODE/MACOS/COPILOT_CONTEXT_FILES/16X9/PIECES_FOR_DEVELOPERS-VS_CODE-COPILOT_CONTEXT_FILES-MACOS-16X9-1_10_2024.GIF" />
+<Image zoom src="https://storage.googleapis.com/pieces_multimedia/PROMOTIONAL/PIECES_FOR_DEVELOPERS/VS_CODE/MACOS/COPILOT_CONTEXT_FILES/16X9/PIECES_FOR_DEVELOPERS-VS_CODE-RELATED_FILES-MACOS-16X9-1_31_2024.GIF.gif" />

--- a/docs/features/pieces-copilot.mdx
+++ b/docs/features/pieces-copilot.mdx
@@ -35,7 +35,7 @@ You can start chatting with the Pieces Copilot using a few different actions:
         - ` Loop over a directory of files and write the first line of their contents to a new text file. `
 3. Drag and Drop a screenshot of code, and the Pieces Copilot will extract the code, explain it, and answer questions about it.
     - Pressing ` Scan Screenshot ` allows you to select a screenshot using your native file picker.
-    - Read about dragging and dropping code into the Pieces Desktop App on the [Saving Screenshots Page](https://docs.pieces.app/product-hihglights-and-benefits/saving-screenshots).
+    - Read about dragging and dropping code into the Pieces Desktop App on the [Saving Screenshots Page](https://docs.pieces.app/product-highlights-and-benefits/saving-screenshots).
 
 ## Results from Pieces Copilot
 When the Pieces Copilot returns code, you will see a few quick actions at the bottom of the code block. These actions include:


### PR DESCRIPTION
Updated the `pieces-copilot.mdx` documentation page to reflect the most current runtimes, and fixed a broken link.