### PR TITLE
Preview Link, No follow research, Expanding docs.page functionality 

### DIFF
--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment Pull Request
-        uses: thollander/actions-comment-pull-request@v2.4.2
+        uses: thollander/actions-comment-pull-request@v2.4.3
         with:
           message: |
             :wave: Preview link --> https://docs.pieces.app/~${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -1,0 +1,14 @@
+name: Documentation Actions
+run-name: Add Preview Link to PR
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  Explore-Github-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment Pull Request
+        uses: thollander/actions-comment-pull-request@v2.4.2
+        with:
+          message: |
+            :wave: Preview link --> https://docs.pieces.app/~${{ github.event.pull_request.number }}

--- a/docs/dev/internal/testing/testing.mdx
+++ b/docs/dev/internal/testing/testing.mdx
@@ -1,0 +1,12 @@
+---
+title: Testing
+description: for internal component testing.
+---
+
+export const iFramed = props => {
+    return <iframe src={"https://code.pieces.app/onboarding/chrome/welcome"} title={"iframe test"}></iframe>
+}
+
+## Hello world
+
+<iFramed></iFramed>

--- a/docs/dev/internal/testing/testing.mdx
+++ b/docs/dev/internal/testing/testing.mdx
@@ -3,10 +3,10 @@ title: Testing
 description: for internal component testing.
 ---
 
-export const iFramed = props => {
+export const Frame = props => {
     return <iframe src={"https://code.pieces.app/onboarding/chrome/welcome"} title={"iframe test"}></iframe>
 }
 
 ## Hello world
 
-<iFramed></iFramed>
+<Frame></Frame>

--- a/docs/dev/internal/testing/testing.mdx
+++ b/docs/dev/internal/testing/testing.mdx
@@ -4,9 +4,9 @@ description: for internal component testing.
 ---
 
 export const Frame = props => {
-    return <iframe src={"https://code.pieces.app/onboarding/chrome/welcome"} title={"iframe test"}></iframe>
+    return <iframe style={{width: "100%", height: "1000px" }} src={"https://code.pieces.app/onboarding/chrome/welcome"} title={"iframe test"}></iframe>
 }
 
-## Hello world
+## Testing iFrames for Onboarding
 
 <Frame></Frame>

--- a/docs/installation-getting-started/windows.mdx
+++ b/docs/installation-getting-started/windows.mdx
@@ -42,6 +42,10 @@ export const Spacer = props => {
     return <div style={{ height: "25px" }}></div>
 }
 
+export const Link = props => {
+    return <a href={props.href}>{props.children}</a>
+}
+
 # Getting Started with Pieces for Developers on Windows
 <ReleasePill>Compatible with Windows 10 Version 1903 or higher</ReleasePill>
 
@@ -56,7 +60,7 @@ export const Spacer = props => {
 
     If this isn't your first rodeo, here is the list of downloadable files for windows:
 
-    - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller)
+    - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | <Link href={"https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller"}>Download Here</Link>
 
     - Pieces for Developers Desktop App Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/pieces_for_x.appinstaller)
 


### PR DESCRIPTION
Lots of changes will be bundled into this one PR around different sections in the repo. Will add to the todo list here as new information is discovered or learned about. Also will connect issues as each one is addressed.

- [x] Add the GH bot back for PR previews - docs.page bot is broken 
- [x] new dev folder for testing single components (iframe example currently): `docs.pieces.app/dev/internal/testing/testing.mdx`
- [x] proof on custom components vs build in `Link` component for nofollow research 
- [x] update the version number for GH bot functionality to [2.4.3](https://github.com/thollander/actions-comment-pull-request) 