### PR TITLE
docs: update help and support  links

### DIFF
--- a/docs/extensions-plugins/azuredatastudio.mdx
+++ b/docs/extensions-plugins/azuredatastudio.mdx
@@ -272,8 +272,7 @@ To uninstall Pieces for Azure Data Studio :
 
 In order for Pieces to be completely uninstalled from Azure Data Studio, you'll need to restart your IDE.
 
-## Help & Support
+## Support and Community 
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-azuredatastudio)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Open Source Program](https://github.com/pieces-app/opensource)

--- a/docs/extensions-plugins/chrome.mdx
+++ b/docs/extensions-plugins/chrome.mdx
@@ -170,8 +170,7 @@ To uninstall Pieces:
 2. Choose "More Actions" next to the Pieces for Developers Chrome Extension
 3. Select "Remove from Chrome"
 
-## Help & Support
+##  Support and Community 
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-chrome)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Open Source Program](https://github.com/pieces-app/opensource)

--- a/docs/extensions-plugins/edge.mdx
+++ b/docs/extensions-plugins/edge.mdx
@@ -156,8 +156,7 @@ To uninstall Pieces:
 2. Choose "More Actions" next to the Pieces for Developers Edge Addon
 3. Select "Remove from Microsoft Edge"
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#docs-edge)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/firefox.mdx
+++ b/docs/extensions-plugins/firefox.mdx
@@ -172,3 +172,7 @@ To uninstall Pieces:
 2. Choose "More Actions" next to the Pieces for Developers Firefox Addon
 3. Select "Remove from Firefox"
 
+## Support and Community
+
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -226,8 +226,7 @@ To uninstall the Pieces for Developers JetBrains Plugin, go to `Plugins > Instal
 
 In order for Pieces to be completely uninstalled from the JetBrains IDE, you'll need to restart your IDE.
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#docs-jetbrains)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/jupyterlab.mdx
+++ b/docs/extensions-plugins/jupyterlab.mdx
@@ -198,8 +198,7 @@ You can adjust the following settings:
 3. Pieces server port
 4. Login/Logout of your Pieces Cloud
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-jupyterlab)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/obsidian.mdx
+++ b/docs/extensions-plugins/obsidian.mdx
@@ -284,8 +284,7 @@ You can adjust the following Settings for the Pieces for Developers Obsidian Plu
 3. Pieces server port
 4. Login/Logout of the Pieces cloud
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-obsidian)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/teams.mdx
+++ b/docs/extensions-plugins/teams.mdx
@@ -161,8 +161,7 @@ When you save a snippet, Pieces also saves metadata such as the origin of the sn
 
 To view and reuse your snippets, just open the [Pieces Desktop App](/installation-getting-started/what-am-i-installing).
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-teams)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)

--- a/docs/extensions-plugins/vscode.mdx
+++ b/docs/extensions-plugins/vscode.mdx
@@ -271,8 +271,7 @@ To uninstall Pieces for VS Code:
 
 In order for Pieces to be completely uninstalled from VS Code, you'll need to restart your IDE. 
 
-## Help & Support
+## Support and Community
 
-- [Contact Us](https://code.pieces.app/contact)
-- [Feedback & Bug Support](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-vscode)
-- [Join our Discord](https://discord.com/invite/getpieces)
+- [Get Support](https://docs.pieces.app/support)
+- [Join our Discord](https://discord.gg/getpieces)


### PR DESCRIPTION
## Description
This PR changes the title and links for the "help and support" section. It ensures that users know where to find help with Pieces. 

## Related Tickets and Documents 
Closes #249 

## Proposed Changes 
Here are the sections I've worked on so far:

- [x] `/azuredatastudio.mdx`
- [x] ` /chrome.mdx`
- [x]  `/edge.mdx`
- [x]  `/firefox.mdx`
- [x]  `/jetbrains.mdx`
- [x]  `/jupyterlab.mdx`
- [x]  `/obsidian.mdx`
- [x]  `/teams.mdx`
- [x]  `/vscode.mdx`

## Note to Reviewers
This is still a work in progress 
**Updates:** Done 