### PR TITLE
docs: mention Tailscale as an alternative for connecting remote URLS

### DIFF
--- a/docs/product-highlights-and-benefits/connecting-to-a-remote-pieces-os-instance.mdx
+++ b/docs/product-highlights-and-benefits/connecting-to-a-remote-pieces-os-instance.mdx
@@ -78,7 +78,7 @@ For Dev Container users, if the connection does not work automatically, there ar
 ### Using the Custom URL Feature to Access a Remote Pieces OS Instance
 
 > - In the case that Pieces OS shares the same LAN with your remote VS Code instance, you should use the LAN IP address of your machine that is running Pieces OS.
-> - In the case that Pieces OS is not on the same LAN as your development environment [ngrok](https://ngrok.com/download), or a similar alternative, must be installed on the machine with Pieces OS. It must be known that doing this will expose your Pieces OS endpoints to the public and this should only be done as a last resort.
+> - In the case that Pieces OS is not on the same LAN as your development environment [ngrok](https://ngrok.com/download), or a similar alternative like [Tailscale](https://tailscale.com/), must be installed on the machine with Pieces OS. It must be known that doing this will expose your Pieces OS endpoints to the public and this should only be done as a last resort.
 > - The custom URL feature has no connection to your custom Pieces Cloud domain, attempting to use your custom Pieces Cloud domain i.e: `https://caleb.pieces.cloud` will result in the VS Code extension ceasing to function properly.
 
 <Tabs


### PR DESCRIPTION
## Description
This PR adds a link to Tailscale in the "Using the Custom URL Feature to Access a Remote Pieces OS Instance" tutorial. It'll help users gain a better understanding of what alternatives to use. 

## Issue
Closes #400 

## Screenshot

![screenshot of tailscale link appearing in tutorial](https://github.com/pieces-app/documentation/assets/105683440/68ba751f-8c49-40b0-9852-c010ee20f22c)
