### PR TITLE
Add categories in sidebar nav for Pieces tools

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -34,49 +34,67 @@ const sidebars: SidebarsConfig = {
           ]
         },
         {
-          type: 'doc',
-          id: 'extensions-plugins/vscode',
-          label: 'VS Code Extension',
+          type: 'category',
+          label: 'Development',
+          items: [
+            {
+              type: 'doc',
+              id: 'extensions-plugins/jetbrains',
+              label: 'JetBrains Plugin',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/sublime',
+              label: 'Sublime Plugin',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/visual-studio',
+              label: 'Visual Studio Extension',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/vscode',
+              label: 'VS Code Extension',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/web-extension',
+              label: 'Web Extension',
+            },
+          ]
         },
         {
-          type: 'doc',
-          id: 'extensions-plugins/web-extension',
-          label: 'Web Extension',
+          type: 'category',
+          label: 'Productivity',
+          items: [
+            {
+              type: 'doc',
+              id: 'extensions-plugins/azure-data-studio',
+              label: 'Azure Data Studio',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/jupyterlab',
+              label: 'JupyterLab Extension',
+            },
+            {
+              type: 'doc',
+              id: 'extensions-plugins/obsidian',
+              label: 'Obsidian Plugin',
+            },
+          ],
         },
         {
-          type: 'doc',
-          id: 'extensions-plugins/jetbrains',
-          label: 'JetBrains Plugin',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/obsidian',
-          label: 'Obsidian Plugin',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/visual-studio',
-          label: 'Visual Studio Extension',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/sublime',
-          label: 'Sublime Plugin',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/azure-data-studio',
-          label: 'Azure Data Studio',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/jupyterlab',
-          label: 'JupyterLab Extension',
-        },
-        {
-          type: 'doc',
-          id: 'extensions-plugins/teams',
-          label: 'Microsoft Teams App',
+          type: 'category',
+          label: 'Communication',
+          items: [
+            {
+              type: 'doc',
+              id: 'extensions-plugins/teams',
+              label: 'Microsoft Teams App',
+            },
+          ]
         },
       ]
     },


### PR DESCRIPTION
Adds three categories, productivity, communication, and development, to separate the Pieces tools from each other so it's more clear and transparent to the user.

Closes https://github.com/pieces-app/documentation/issues/515

- https://github.com/pieces-app/documentation/issues/515

<img width="941" alt="Screenshot 2024-08-05 192847" src="https://github.com/user-attachments/assets/2afa14fc-aa30-410c-8ae7-0e3bdd9b0010">