### PR TITLE
(Fixed) Installation method redirect URL

### DIFF
--- a/docs/installation-getting-started/pieces-os.mdx
+++ b/docs/installation-getting-started/pieces-os.mdx
@@ -23,7 +23,7 @@ Pieces OS enables Pieces products to operate 100% locally on your machine, with 
 
 :::info
 
-Downloading Pieces OS by itself is not recommended, but is the right solution for specific situations. [Download Pieces Desktop + Pieces OS together](/installation-getting-started/what-am-i-installing) for the most ideal experience.
+Downloading Pieces OS by itself is not recommended, but is the right solution for specific situations. [Download Pieces Desktop + Pieces OS together](/installation-getting-started/what-am-i-installing#pieces-desktop-app--pieces-os) for the most ideal experience.
 
 :::
 


### PR DESCRIPTION
Fixes #516

The `Download Pieces Desktop + Pieces OS together` link now directly redirects to https://docs.pieces.app/installation-getting-started/what-am-i-installing#pieces-desktop-app--pieces-os 