### PR TITLE
Update MacOS download page

### DIFF
--- a/docs/installation-getting-started/macos.mdx
+++ b/docs/installation-getting-started/macos.mdx
@@ -28,15 +28,19 @@ import ReleasePill from "/src/components/ReleasePill";
 
 <Spacer />
 
+:::info
+
+If you aren't sure which of these you need, check your computer's processor:
+1. Click the Apple logo in the top left corner of your screen
+2. Select "About this Mac"
+3. Check "Chip" in the window that pops up.
+
+If you have an Intel chip, select the Intel package above. Those with Apple M1 or M2 chips should select the "Apple Silicon" package.
+
+:::
+
 <details>
   <summary>Alternative Installation Methods</summary>
-
-  If you aren't sure which of these you need, check your computer's processor:
-  1. Click the Apple logo in the top left corner of your screen
-  2. Select "About this Mac"
-  3. Check "Chip" in the window that pops up.
-
-  If you have an Intel chip, select the Intel package above. Those with Apple M1 or M2 chips should select the "Apple Silicon" package.
 
   If this isn't your first rodeo, here is the list of downloadable files for macOS:
   - [Pieces OS](/installation-getting-started/pieces-os) DMG (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg/download)


### PR DESCRIPTION
There's a dropdown "alternative installation methods" that clarifies which of the options to choose was moved in a separate infobox.

Why this isn't a pop-up box on hover:
This might cause some friction when the user wants to access certain information in the docs, and we want to reduce as much friction as possible.

- https://github.com/pieces-app/documentation/issues/504

Fixes https://github.com/pieces-app/documentation/issues/504

<img width="494" alt="Screenshot 2024-08-06 181725" src="https://github.com/user-attachments/assets/6b596b18-1f89-4e53-8cf2-4972f9cc334f">
