### PR TITLE
Fix Typescript SDK code snippet

### DIFF
--- a/docs/build/reference/typescript/index.mdx
+++ b/docs/build/reference/typescript/index.mdx
@@ -99,7 +99,7 @@ if (platform === 'linux') {
 }
 
 // The `basePath` defaults to http://localhost:1000, however we need to change it to the correct port based on the operating system.
-const configuration = Pieces.Configuration({
+const configuration = new Pieces.Configuration({
   basePath: `http://localhost:${port}`
 })
 // Create an instance of the WellKnownApi class


### PR DESCRIPTION
fixes #536 

I updated the code snippet for creating a Pieces configuration with the "new" keyword because it gives an error without it.