### PR TITLE
Open command docs updation 

### DIFF
--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -72,7 +72,7 @@ Lists all accessible AI models.
 pieces list models
 ```
 
-#### open (deprecated)
+### `open` (deprecated)
 Opens an asset from a list or search. If only "open" is used, it opens the most recent asset. This also creates a link to the asset's code.
 
 ```bash

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -94,6 +94,18 @@ pieces open [ITEM_INDEX]
 
  ```pieces config editor <editor_command>```
 
+The editor_command refers to the command used to launch your preferred text editor from the command line. Here are some examples:
+
+- For Visual Studio Code: Use ```code```
+- For Sublime Text: Use ```subl```
+- For Vim: Use ```vim```
+- For Emacs: Use ```emacs```
+- For Nano: Use ```nano```
+
+For instance, to set Visual Studio Code as your editor, you would run:
+
+``` pieces config editor code ```
+
 > Previous implementations of the open command are now deprecated. 
 
 ### `save`

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -73,11 +73,21 @@ pieces list models
 ```
 
 ### `open`
-Opens an asset from a list or search. If only "open" is used, it opens the most recent asset.
+Opens an asset from a list or search. If only "open" is used, it opens the most recent asset. This also creates a link to the asset's code.
 
 ```bash
-pieces open [ITEM_INDEX]
+pieces open [ITEM_INDEX] [-e]
 ```
+
+```-e``` is an optional flag . It Opens the asset in the configured external editor. Editor of choice can be configured using config command.
+
+ ##### Editor Configuration:
+
+ You can configure an external editor to open assets for editing. Use the following command to set your preferred editor:
+
+ ```pieces config editor <editor_command>```
+
+#### NOTE : previous implementations of the open command are now deprecated. 
 
 ### `save`
 Saves changes to the current asset. You need to edit the snippet code that was opened via the `open` command and then save the changes using the save command.

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -58,6 +58,15 @@ Displays your `x` most recent assets.
 pieces list assets x
 ```
 
+#### List Editor Opening 
+Opens the Assets in the configured editor of choice.
+
+```bash 
+list assets -e
+ ```
+
+ ```-e``` is a flag that opens the asset in the configured external editor. Editor of choice can be configured using config command.
+
 #### List Applications
 Lists all registered applications.
 
@@ -76,10 +85,8 @@ pieces list models
 Opens an asset from a list or search. If only "open" is used, it opens the most recent asset. This also creates a link to the asset's code.
 
 ```bash
-pieces open [ITEM_INDEX] [-e]
+pieces open [ITEM_INDEX]
 ```
-
-```-e``` is an optional flag . It Opens the asset in the configured external editor. Editor of choice can be configured using config command.
 
  ##### Editor Configuration:
 

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -88,7 +88,7 @@ Opens an asset from a list or search. If only "open" is used, it opens the most 
 pieces open [ITEM_INDEX]
 ```
 
- ##### Editor Configuration:
+ #### Editor Configuration:
 
  You can configure an external editor to open assets for editing. Use the following command to set your preferred editor:
 

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -87,7 +87,7 @@ pieces open [ITEM_INDEX] [-e]
 
  ```pieces config editor <editor_command>```
 
-#### NOTE : previous implementations of the open command are now deprecated. 
+> Previous implementations of the open command are now deprecated. 
 
 ### `save`
 Saves changes to the current asset. You need to edit the snippet code that was opened via the `open` command and then save the changes using the save command.

--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -72,7 +72,7 @@ Lists all accessible AI models.
 pieces list models
 ```
 
-### `open`
+#### open (deprecated)
 Opens an asset from a list or search. If only "open" is used, it opens the most recent asset. This also creates a link to the asset's code.
 
 ```bash


### PR DESCRIPTION
## Description 
Updated the documentation to correctly reflect the changes in the open command implementation 

## Changes 

- added the docs for the -e flag 
- added the section for editor configurations 
- added note to indicate deprecation of the previous implementation of the open command 

## Objective 

- completely resolves pieces-app/cli-agent#156
- keeps the docs updated and inline with the readme of the updated version of the project.