### PR TITLE
Added Discord link for more causal discussions

### DIFF
--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -66,3 +66,4 @@ You can also check out our [FAQs page](https://docs.pieces.app/faq) for solution
 ## Still need help? Our support team is here to help!
 
 If you prefer to not use GitHub, please [submit a support ticket](https://getpieces.typeform.com/to/mCjBSIjF#page=docs-support). We appreciate your feedback and will respond to you shortly!
+Join our community on [Discord](https://discord.com/invite/getpieces) for more casual discussions and support.


### PR DESCRIPTION
### Description:
This PR addresses issue https://github.com/pieces-app/documentation/issues/545 by adding a link to our Discord server on the support page. The goal is to provide users with an additional platform for casual discussions, quick questions, and community engagement.