### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/build/sdks/python/quickstart.mdx
+++ b/docs/build/sdks/python/quickstart.mdx
@@ -91,7 +91,7 @@ pieces_client = PiecesClient()
 # Get all assets and print their names
 assets = pieces_client.assets()
 for asset in assets:
-   logger.info(f"Asset Name: {asset.name}")
+   print(f"Asset Name: {asset.name}")
 
 # Close the client
 pieces_client.close()


### PR DESCRIPTION
Since a logger is not imported in the snippet, a simple print() makes sense here.