### PR TITLE
fix:corrected pynvim installation instruction in neovim plugin docs

### DIFF
--- a/docs/extensions-plugins/neovim/quickstart.mdx
+++ b/docs/extensions-plugins/neovim/quickstart.mdx
@@ -29,7 +29,7 @@ A few things to note before you start installing the Pieces Neovim Plugin:
 - The Python based Neovim plugins requires the `pynvim` Python package, which is not included in the default Neovim installation. You can install it by running the following command:
 
     ```bash
-    pip install pynvim
+    sudo apt install python3-pynvim
     ```
 
 - Ensure that you have at least one Neovim package manager installed. For instance, you can install `vim-plug`. 


### PR DESCRIPTION
#562 
This PR updates the documentation to provide the correct installation command for pynvim on Debian-based systems. Previously, the documentation suggested using `pip install pynvim`, which always leads to errors in externally managed environments.

By using `sudo apt install python3-pynvim`, users can ensure that `pynvim` is installed correctly and can be used by the plugin.