### PR TITLE
Add execute command to CLI documentation

### DIFF
--- a/docs/extensions-plugins/cli/commands.mdx
+++ b/docs/extensions-plugins/cli/commands.mdx
@@ -121,6 +121,14 @@ Creates a new asset from the clipboard content. The asset will automatically be 
 ```bash
 pieces create
 ```
+### `execute`
+Executes shell or bash assets. You can optionally specify the maximum number of assets to display.
+
+```bash 
+pieces execute [max_assets]
+```
+
+max_assets: (Optional) The maximum number of assets to display. Default is 10.
 
 ### `edit`
 Edits the name and classification of the current asset.


### PR DESCRIPTION
## Description
This PR adds documentation for the new 'execute' command to our CLI tool's documentation. The 'execute' command allows users to run shell or bash assets with an optional limit on the number of assets to display.

## Changes

- Add 'execute' command description to the CLI documentation
- Include explanation of the optional max_assets argument

## Checklist

 [x] Documentation has been updated
 [x] Changes have been tested locally
 [x] Formatting is consistent with existing documentation

Related Issues
Closes  https://github.com/pieces-app/cli-agent/issues/177