### PR TITLE
docs:fixed the pynvim installation command in quickstart

### DIFF
--- a/docs/extensions-plugins/neovim/quickstart.mdx
+++ b/docs/extensions-plugins/neovim/quickstart.mdx
@@ -33,7 +33,7 @@ A few things to note before you start installing the Pieces Neovim Plugin:
     pip install pynvim
     ```
    
-  If you use Debian/Ubuntu/Ubuntu-based-distro -
+  If you use Ubuntu 22+ or an Ubuntu-based-distro -
    
     ```bash
     sudo apt install python3-pynvim

--- a/docs/extensions-plugins/neovim/quickstart.mdx
+++ b/docs/extensions-plugins/neovim/quickstart.mdx
@@ -26,10 +26,17 @@ In this tutorial, we'll walk you through the process of setting up and using the
 
 A few things to note before you start installing the Pieces Neovim Plugin:
 
-- The Python based Neovim plugins requires the `pynvim` Python package, which is not included in the default Neovim installation. You can install it by running the following command:
+- The Python based Neovim plugins requires the `pynvim` Python package, which is not included in the default Neovim installation. 
+  You can install it in MacOS/Windows by running the following command:
 
     ```bash
     pip install pynvim
+    ```
+   
+  If you use Debian/Ubuntu/Ubuntu-based-distro -
+   
+    ```bash
+    sudo apt install python3-pynvim
     ```
 
 - Ensure that you have at least one Neovim package manager installed. For instance, you can install `vim-plug`. 


### PR DESCRIPTION
#562 

Previously the provided command could successfully work in only Windows and MacOS. I added the command for Debian/Ubuntu/(Ubuntu based distros) because python packages are globally installed differently in a Linux OS.  
  
My previous PR did not consider about Windows/MacOS, so changes were requested by @shivay-at-pieces. This is the new PR considering both Windows, MacOS and Debian based Linux Operating Systems.  
  
Hope it helps.