### PR TITLE
Query params for download urls

### DIFF
--- a/docs/extensions-plugins/teams.mdx
+++ b/docs/extensions-plugins/teams.mdx
@@ -101,7 +101,7 @@ Need a little help with Pieces for Microsoft Teams? Both the "Help” & "Hi” c
 
 ## Where are my saved snippets stored?
 
-_The <a href={pieces_app.links.installation.pieces_suite_manager}>Pieces Suite</a> must be downloaded and installed separately from the Microsoft Teams App in order for the extension to work properly._
+_The [Pieces Suite](/installation-getting-started/what-am-i-installing) must be downloaded and installed separately from the Microsoft Teams App in order for the extension to work properly._
 
 When you save code snippets with Pieces, they are stored locally in the Pieces desktop app.
 When you save a snippet, Pieces also saves metadata such as the origin of the snippet, tags, a title, a description, and more.

--- a/docs/installation-getting-started/macos.mdx
+++ b/docs/installation-getting-started/macos.mdx
@@ -7,6 +7,9 @@ import { pieces_app } from "/src/lib/const";
 import { MiniSpacer, Spacer } from "/src/components/Spacers";
 import CTAButton from "/src/components/CTAButton";
 import ReleasePill from "/src/components/ReleasePill";
+import DownloadLinkUpdater from "/src/components/DownloadLinkUpdater";
+
+<DownloadLinkUpdater />
 
 # Getting Started with Pieces for Developers on macOS
 

--- a/docs/installation-getting-started/pieces-os.mdx
+++ b/docs/installation-getting-started/pieces-os.mdx
@@ -7,6 +7,9 @@ import GridFlexRow from "/src/components/GridFlexRow";import Tabs from '@theme/T
 import TabItem from '@theme/TabItem';
 import { MiniSpacer } from '/src/components/Spacers';
 import CTAButton from "/src/components/CTAButton";
+import DownloadLinkUpdater from "/src/components/DownloadLinkUpdater";
+
+<DownloadLinkUpdater />
 
 # What is Pieces OS?
 

--- a/docs/installation-getting-started/windows.mdx
+++ b/docs/installation-getting-started/windows.mdx
@@ -7,6 +7,9 @@ import { pieces_app } from "/src/lib/const";
 import { Spacer } from "/src/components/Spacers";
 import CTAButton from "/src/components/CTAButton";
 import ReleasePill from "/src/components/ReleasePill";
+import DownloadLinkUpdater from "/src/components/DownloadLinkUpdater";
+
+<DownloadLinkUpdater />
 
 # Getting Started with Pieces for Developers on Windows
 <ReleasePill>Compatible with Windows 10 Version 1903 or higher</ReleasePill>

--- a/src/components/CTAButton/index.tsx
+++ b/src/components/CTAButton/index.tsx
@@ -13,38 +13,15 @@ type CTAButtonProps = {
   fullWidth?: boolean
 }
 
-// Define the type for gaGlobal
-interface GaGlobal {
-  vid: string;
-  from_cookie: boolean;
-}
-
-// Check if gaGlobal exists in the global scope
-declare const gaGlobal: GaGlobal | undefined;
-
 const CTAButton = ({ ...props }: CTAButtonProps) => {
   const { colorMode } = useColorMode();
-  const [href, setHref] = useState(props.href);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && typeof gaGlobal !== 'undefined') {
-      const vid = gaGlobal.vid;
-
-      if (props.href?.startsWith('https://builds.pieces.app/stages/production')) {
-        // Need to ensure that vid is defined before appending it to the query string
-        const updatedHref = `${props.href}?download=true&product=DOCUMENTATION_WEBSITE${vid && `&visitor=${vid}`}`;
-        setHref(updatedHref);
-        console.log('Updated href:', updatedHref);
-      }
-    }
-  }, []);
 
   // If the href starts with http, open in a new tab
-  const newTab = href?.startsWith('http');
+  const newTab = props.href?.startsWith('http');
 
   return (
     <a
-      href={href} // Use the state variable here instead of props.href
+      href={props.href}
       className={'cta-button'}
       style={{
         fontSize: props.type === 'secondary' ? '1rem' : '1.25rem',

--- a/src/components/CTAButton/index.tsx
+++ b/src/components/CTAButton/index.tsx
@@ -34,6 +34,7 @@ const CTAButton = ({ ...props }: CTAButtonProps) => {
         // Need to ensure that vid is defined before appending it to the query string
         const updatedHref = `${props.href}?download=true&product=DOCUMENTATION_WEBSITE${vid && `&visitor=${vid}`}`;
         setHref(updatedHref);
+        console.log('Updated href:', updatedHref);
       }
     }
   }, []);

--- a/src/components/DownloadLinkUpdater/index.tsx
+++ b/src/components/DownloadLinkUpdater/index.tsx
@@ -26,12 +26,14 @@ const DownloadLinkUpdater: React.FC = () => {
           // Construct the new href with the required query parameters
           const newHref = `${currentHref}?download=true&product=DOCUMENTATION_WEBSITE${vid ? `&visitor=${vid}` : ''}`;
 
-          console.log('Updated href from updater:', newHref);
-
           // Update the href attribute on the link
           link.setAttribute('href', newHref);
         }
       });
+    } else {
+      if (typeof window && typeof gaGlobal === 'undefined') {
+        console.warn('gaGlobal is not defined in local development');
+      }
     }
   }, []); // Empty dependency array means this effect runs only once after the component mounts
 

--- a/src/components/DownloadLinkUpdater/index.tsx
+++ b/src/components/DownloadLinkUpdater/index.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+
+// Define the type for gaGlobal
+interface GaGlobal {
+  vid: string;
+  from_cookie: boolean;
+}
+
+// Check if gaGlobal exists in the global scope
+declare const gaGlobal: GaGlobal | undefined;
+
+const DownloadLinkUpdater: React.FC = () => {
+  useEffect(() => {
+    // Ensure the window object is available, indicating we're in the browser
+    if (typeof window !== 'undefined' && typeof gaGlobal !== 'undefined') {
+      const vid = gaGlobal.vid; // Extract the visitor ID from the global gaGlobal object
+
+      // Get all anchor (<a>) elements on the page
+      const links = document.querySelectorAll('a[href^="https://builds.pieces.app/stages/production"]');
+
+      // Loop through each link and update its href
+      links.forEach(link => {
+        const currentHref = link.getAttribute('href');
+
+        if (currentHref) {
+          // Construct the new href with the required query parameters
+          const newHref = `${currentHref}?download=true&product=DOCUMENTATION_WEBSITE${vid ? `&visitor=${vid}` : ''}`;
+
+          // Update the href attribute on the link
+          link.setAttribute('href', newHref);
+        }
+      });
+    }
+  }, []); // Empty dependency array means this effect runs only once after the component mounts
+
+  return null; // This component doesn’t need to render anything
+};
+
+export default DownloadLinkUpdater;

--- a/src/components/DownloadLinkUpdater/index.tsx
+++ b/src/components/DownloadLinkUpdater/index.tsx
@@ -26,6 +26,8 @@ const DownloadLinkUpdater: React.FC = () => {
           // Construct the new href with the required query parameters
           const newHref = `${currentHref}?download=true&product=DOCUMENTATION_WEBSITE${vid ? `&visitor=${vid}` : ''}`;
 
+          console.log('Updated href from updater:', newHref);
+
           // Update the href attribute on the link
           link.setAttribute('href', newHref);
         }


### PR DESCRIPTION
Decided to make the logic into a component instead of having it only for the CTA button so that it updates any link, even regular `a` tags. Then we just import the component into each page with download links on it instead. This is better than injecting the script into the head of each page since only a couple of pages have download links on them out of the hundreds/thousands of pages on the docs site.