### PR TITLE
Renaming live context to long term memory

### DIFF
--- a/docs/build/reference/python/apis/77-WorkstreamPatternEngineApi.md
+++ b/docs/build/reference/python/apis/77-WorkstreamPatternEngineApi.md
@@ -19,7 +19,7 @@ Method | HTTP request | Description
 
 /workstream_pattern_engine/processors/vision/activate [POST]
 
-This will activate your Workstream Pattern Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will activate your Long-Term Memory Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstream_pattern_engine_processors_vision_activate-example}
 
@@ -88,7 +88,7 @@ No authorization required
 
 /workstream_pattern_engine/processors/vision/data/clear [POST]
 
-This will clear the data for the Workstream Pattern Engine, specifically for our vision data.  This boy will accept ranges of time that the user wants to remove the processing from.
+This will clear the data for the Long-Term Memory Engine, specifically for our vision data.  This boy will accept ranges of time that the user wants to remove the processing from.
 
 ### Example {#workstream_pattern_engine_processors_vision_data_clear-example}
 
@@ -155,7 +155,7 @@ No authorization required
 
 /workstream_pattern_engine/processors/vision/deactivate [POST]
 
-This will deactivate your Workstream Pattern Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will deactivate your Long-Term Memory Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstream_pattern_engine_processors_vision_deactivate-example}
 
@@ -224,7 +224,7 @@ No authorization required
 
 /workstream_pattern_engine/processors/vision/status [GET]
 
-This will get a snapshot of the status your Workstream Pattern Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will get a snapshot of the status your Long-Term Memory Engine. This is used to aggregate information on your user's desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstream_pattern_engine_processors_vision_status-example}
 

--- a/docs/build/reference/python/models/231-QGPTConversationPipeline.md
+++ b/docs/build/reference/python/models/231-QGPTConversationPipeline.md
@@ -4,7 +4,7 @@ title: QGPTConversationPipeline | Python SDK
 
 # QGPTConversationPipeline
 
-This model is specifically for QGPT Conversation pipelines, the model is used to group conversational prompts for instance a conversation around generating code.  here are some use cases- 1. contextualized_code_generation- This is for users that want to have conversations around generating code, when there is provided context. 2. generalized_code- This is for users that want to have conversations without context around code. 3. contextualized_code- This is for users that want to have conversation around code with Context. 4. contextualized_code_workstream: this is for the users that want to use context as well as WPE information in their chat (we wiil prioritize WPE infomration, but also support other info as well)
+This model is specifically for QGPT Conversation pipelines, the model is used to group conversational prompts for instance a conversation around generating code.  here are some use cases- 1. contextualized_code_generation- This is for users that want to have conversations around generating code, when there is provided context. 2. generalized_code- This is for users that want to have conversations without context around code. 3. contextualized_code- This is for users that want to have conversation around code with Context. 4. contextualized_code_workstream: this is for the users that want to use context as well as LTME information in their chat (we will prioritize LTME information, but also support other info as well)
 
 ## Properties
 

--- a/docs/build/reference/python/models/234-QGPTConversationPipelineForContextualizedCodeWorkstreamDialog.md
+++ b/docs/build/reference/python/models/234-QGPTConversationPipelineForContextualizedCodeWorkstreamDialog.md
@@ -4,7 +4,7 @@ title: QGPTConversationPipelineForContextualizedCodeWorkstreamDialog | Python SD
 
 # QGPTConversationPipelineForContextualizedCodeWorkstreamDialog
 
-This is for the users that wants to have contextualized code conversations around their workstream materials, meaning conversations around code with Context provided, as well as workstream information ie information gathered from the WPE.  This is a class so that we can add optional properties in the future.
+This is for the users that wants to have contextualized code conversations around their workstream materials, meaning conversations around code with Context provided, as well as workstream information ie information gathered from the LTME.  This is a class so that we can add optional properties in the future.
 
 ## Properties
 

--- a/docs/build/reference/typescript/apis/71-WorkstreamPatternEngineApi.md
+++ b/docs/build/reference/typescript/apis/71-WorkstreamPatternEngineApi.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 ## **workstreamPatternEngineProcessorsVisionActivate** {#workstreampatternengineprocessorsvisionactivate}
 > WorkstreamPatternEngineStatus workstreamPatternEngineProcessorsVisionActivate()
 
-This will activate your Workstream Pattern Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will activate your Long-Term Memory Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstreampatternengineprocessorsvisionactivate-example}
 
@@ -65,7 +65,7 @@ Name | Type | Description  | Notes
 ## **workstreamPatternEngineProcessorsVisionDataClear** {#workstreampatternengineprocessorsvisiondataclear}
 > workstreamPatternEngineProcessorsVisionDataClear()
 
-This will clear the data for the Workstream Pattern Engine, specifically for our vision data.  This boy will accept ranges of time that the user wants to remove the processing from.
+This will clear the data for the Long-Term Memory Engine, specifically for our vision data.  This boy will accept ranges of time that the user wants to remove the processing from.
 
 ### Example {#workstreampatternengineprocessorsvisiondataclear-example}
 
@@ -113,7 +113,7 @@ void (empty response body)
 ## **workstreamPatternEngineProcessorsVisionDeactivate** {#workstreampatternengineprocessorsvisiondeactivate}
 > WorkstreamPatternEngineStatus workstreamPatternEngineProcessorsVisionDeactivate()
 
-This will deactivate your Workstream Pattern Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will deactivate your Long-Term Memory Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstreampatternengineprocessorsvisiondeactivate-example}
 
@@ -161,7 +161,7 @@ Name | Type | Description  | Notes
 ## **workstreamPatternEngineProcessorsVisionStatus** {#workstreampatternengineprocessorsvisionstatus}
 > WorkstreamPatternEngineStatus workstreamPatternEngineProcessorsVisionStatus()
 
-This will get a snapshot of the status your Workstream Pattern Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
+This will get a snapshot of the status your Long-Term Memory Engine. This is used to aggregate information on your user\'s desktop, specifically recording the application in focus and aggregating relevant context that will then be used to ground the copilot conversations, as well as the feed.  Note: required to be a beta user to use this feature until this is live(roughly mid to late April)
 
 ### Example {#workstreampatternengineprocessorsvisionstatus-example}
 

--- a/docs/build/reference/typescript/models/236-QGPTConversationPipeline.md
+++ b/docs/build/reference/typescript/models/236-QGPTConversationPipeline.md
@@ -5,7 +5,7 @@ title: QGPTConversationPipeline | TypeScript SDK
 
 # QGPTConversationPipeline
 
-This model is specifically for QGPT Conversation pipelines, the model is used to group conversational prompts for instance a conversation around generating code.  here are some use cases- 1. contextualized_code_generation- This is for users that want to have conversations around generating code, when there is provided context. 2. generalized_code- This is for users that want to have conversations without context around code. 3. contextualized_code- This is for users that want to have conversation around code with Context. 4. contextualized_code_workstream: this is for the users that want to use context as well as WPE information in their chat (we wiil prioritize WPE infomration, but also support other info as well)
+This model is specifically for QGPT Conversation pipelines, the model is used to group conversational prompts for instance a conversation around generating code.  here are some use cases- 1. contextualized_code_generation- This is for users that want to have conversations around generating code, when there is provided context. 2. generalized_code- This is for users that want to have conversations without context around code. 3. contextualized_code- This is for users that want to have conversation around code with Context. 4. contextualized_code_workstream: this is for the users that want to use context as well as LTME information in their chat (we will prioritize LTME information, but also support other info as well)
 
 ## Properties
 

--- a/docs/build/reference/typescript/models/239-QGPTConversationPipelineForContextualizedCodeWorkstreamDialog.md
+++ b/docs/build/reference/typescript/models/239-QGPTConversationPipelineForContextualizedCodeWorkstreamDialog.md
@@ -5,7 +5,7 @@ title: QGPTConversationPipelineForContextualizedCodeWorkstreamDialog | TypeScrip
 
 # QGPTConversationPipelineForContextualizedCodeWorkstreamDialog
 
-This is for the users that wants to have contextualized code conversations around their workstream materials, meaning conversations around code with Context provided, as well as workstream information ie information gathered from the WPE.  This is a class so that we can add optional properties in the future.
+This is for the users that wants to have contextualized code conversations around their workstream materials, meaning conversations around code with Context provided, as well as workstream information ie information gathered from the LTME.  This is a class so that we can add optional properties in the future.
 
 ## Properties
 

--- a/docs/community/events/ama/building-a-more-extensible-development-environment.mdx
+++ b/docs/community/events/ama/building-a-more-extensible-development-environment.mdx
@@ -19,7 +19,7 @@ Join us for an exciting live Ask Me Anything (AMA) session where the Pieces team
 
 Plus, learn how you can create your own Pieces integration with our multilingual open-source SDKs, example projects, and brand-new documentation site.
 
-Finally, we’ll be giving you a sneak peek into our Workstream Pattern Engine technology which enables you to contextualize your Pieces Copilot from every tool in your workflow, making traditional extensibility a thing of the past.
+Finally, we’ll be giving you a sneak peek into our Long-Term Memory Engine technology which enables you to contextualize your Pieces Copilot from every tool in your workflow, making traditional extensibility a thing of the past.
 
 Register now and send us your questions ahead of time - your thoughts and opinions mean the world to us!
 
@@ -34,7 +34,7 @@ Register now and send us your questions ahead of time - your thoughts and opinio
 - **Feature Demo:** Get a first look at the current features, use cases for the extension, and sneak peeks at what’s coming next to elevate your coding experience.
 - **Open Source Essentials:** Explore our newly minted SDK Docs and hands-on example projects to help get you started.
 - **Python CLI Agent:** Discover the AI capabilities and opportunities of our new open-source CLI Agent, a new way to interact with your code and context.
-- **Workstream Pattern Engine:** Experience the future of AI assistance with our new technology (currently in Beta) that understands your entire workflow.
+- **Long-Term Memory Engine:** Experience the future of AI assistance with our new technology (currently in Beta) that understands your entire workflow.
 
 ## 💡 Who Should Attend? {#who-should-attend}
 This AMA is perfect for developers, tech enthusiasts, and anyone keen on enhancing their coding workflow. Whether you're a seasoned pro or just starting out, there's something for everyone.

--- a/docs/community/events/ama/live-context-security-and-privacy.mdx
+++ b/docs/community/events/ama/live-context-security-and-privacy.mdx
@@ -1,6 +1,6 @@
 ---
-title: AMA - Security & Privacy of Live Context in Pieces Copilot+
-description: Join us on Tuesday, June 18 at 12:00pm EST for a technical deep dive on our Live Context feature, and the security and privacy implications behind it.
+title: AMA - Security & Privacy of Long-Term Memory in Pieces Copilot+
+description: Join us on Tuesday, June 18 at 12:00pm EST for a technical deep dive on our Long-Term Memory feature, and the security and privacy implications behind it.
 displayed_sidebar: docsSidebar
 ---
 
@@ -8,34 +8,36 @@ import CTAButton from "/src/components/CTAButton";
 import SocialIcons from "/src/components/SocialIcons";
 import {MiniSpacer} from "/src/components/Spacers";
 
-# Under the Hood with Pieces: Deep Dive into the Security & Privacy of Live Context in Pieces Copilot+
+# Under the Hood with Pieces: Deep Dive into the Security & Privacy of Long-Term Memory in Pieces Copilot+
 
 > Live Stream Event - Tuesday, June 18, 12:00pm EST
 
-![Live Context Security & Privacy AMA](/ama/live-context-security-and-privacy.png)
+![Long-Term Memory Security & Privacy AMA](/ama/live-context-security-and-privacy.png)
+
+> Note: Long-Term Memory is the new name for Pieces Live Context. You may still see this older name in our videos and documentation.
 
 ## 🚀 Event Overview {#event-overview}
-Just two days after the [announcement of our Live Context feature](https://www.youtube.com/watch?v=aP8u95RTCGE) in Pieces Copilot+, Microsoft announced their Copilot+ PC with “photographic memory” which “helps you remember things you may have forgotten”.
+Just two days after the [announcement of our Long-Term Memory feature](https://www.youtube.com/watch?v=aP8u95RTCGE) in Pieces Copilot+, Microsoft announced their Copilot+ PC with “photographic memory” which “helps you remember things you may have forgotten”.
 
 This launch unexpectedly brought many questions about the security and privacy of AI engines at the operating-system level, with many developers and organizations concerned about their sensitive data.
 
-In this AMA (Ask Me Anything) live stream event, we’ll be uncovering the tech behind our Live Context feature powered by the Workstream Pattern Engine (WPE) to showcase our commitment to air-gapped developer experiences, and discuss the benefits of an offline-first approach to using AI to remember the right things, not everything.
+In this AMA (Ask Me Anything) live stream event, we’ll be uncovering the tech behind our Long-Term Memory feature powered by the Long-Term Memory Engine (LTME) to showcase our commitment to air-gapped developer experiences, and discuss the benefits of an offline-first approach to using AI to remember the right things, not everything.
 
-It was far from easy to develop this feature without relying on traditional cloud-based recording methods that can lead to security vulnerabilities, but ultimately we were able to create the WPE technology which works across all major operating systems, operates on-device and in real-time for extremely robust security and privacy, avoids network latency, liability of data, and expensive cloud costs, and enables developers to 10x their productivity.
+It was far from easy to develop this feature without relying on traditional cloud-based recording methods that can lead to security vulnerabilities, but ultimately we were able to create the LTME technology which works across all major operating systems, operates on-device and in real-time for extremely robust security and privacy, avoids network latency, liability of data, and expensive cloud costs, and enables developers to 10x their productivity.
 
 Learn more about our development journey and what this means for your workflow by registering for the live stream!
 
 <CTAButton href={'https://getpieces.typeform.com/to/OvKdlD2r'} label={'Register Now'} type={'primary'} />
 
 ## 🛠 What You'll Learn {#what-youll-learn}
-- **Security & Privacy First:** Discover how Live Context operates entirely on-device, ensuring your workflow data never leaves your computer.
-- **Workstream Pattern Engine:** Understand the technology that shadows your workflow, capturing context locally across macOS, Windows, and Linux.
-- **Behind the Scenes:** Get insights into the algorithms and models that power Live Context, including intelligent visual snapshots, OCR models, and the summarization & redaction step.
+- **Security & Privacy First:** Discover how Long-Term Memory operates entirely on-device, ensuring your workflow data never leaves your computer.
+- **Long-Term Memory Engine:** Understand the technology that shadows your workflow, capturing context locally across macOS, Windows, and Linux.
+- **Behind the Scenes:** Get insights into the algorithms and models that power Long-Term Memory, including intelligent visual snapshots, OCR models, and the summarization & redaction step.
 - **Local LLM Execution:** Learn how we leverage on-device LLM runtimes to keep your data private, with no need for cloud-based processing.
 
 ## 💡 Why Attend? {#why-attend}
 - **Interactive Q&A:** Our founder and key engineers will be on hand to answer your questions live.
-- **In-Depth Technical Breakdown:** Gain a deeper understanding of how Live Context seamlessly integrates into your development workflow while maintaining top-tier security.
+- **In-Depth Technical Breakdown:** Gain a deeper understanding of how Long-Term Memory seamlessly integrates into your development workflow while maintaining top-tier security.
 - **Community Engagement:** Share your thoughts, feedback, and ideas to help us refine this feature for all developers.
 
 ## ❓ How to Participate {#how-to-participate}

--- a/docs/features/pieces-copilot.mdx
+++ b/docs/features/pieces-copilot.mdx
@@ -75,13 +75,13 @@ These snippets help the Copilot understand the precise syntax and functionality 
 
 ![Setting Context for the Pieces Copilot](/assets/contextual_copilot.png)
 
-### Live Context
-[Live Context](/product-highlights-and-benefits/live-context) comes from the [Workstream Pattern Engine](/product-highlights-and-benefits/live-context#the-workstream-pattern-engine) and enables the copilot to capture real-time context from any application on your desktop, making it aware of your recent activities and work-in-progress journey. This dynamic understanding allows the copilot to provide hyper-personalized responses and suggestions based on your recent workflow.
+### Long-Term Memory
+[Long-Term Memory](/product-highlights-and-benefits/live-context) comes from the [Long-Term Memory Engine](/product-highlights-and-benefits/live-context#the-workstream-pattern-engine) and enables the copilot to capture real-time context from any application on your desktop, making it aware of your recent activities and work-in-progress journey. This dynamic understanding allows the copilot to provide hyper-personalized responses and suggestions based on your recent workflow.
 
-By enabling the Workstream Pattern Engine in the Pieces settings, the copilot can reference your recent activities, discussions, and code changes, tailoring its responses and interactions to your unique project.
+By enabling the Long-Term Memory in the Pieces settings, the copilot can reference your recent activities, discussions, and code changes, tailoring its responses and interactions to your unique project.
 
 #### Temporal and Conversational Awareness
-Live Context allows for a more intuitive and seamless interaction with the copilot, as it can recall and reference recent work contexts and discussions on a time-basis. Whether you're asking about a recent error, a discussion point with a colleague, or to summarize your workflow yesterday, the copilot uses its temporally grounded knowledge to provide relevant and timely assistance.
+Long-Term Memory allows for a more intuitive and seamless interaction with the copilot, as it can recall and reference recent work contexts and discussions on a time-basis. Whether you're asking about a recent error, a discussion point with a colleague, or to summarize your workflow yesterday, the copilot uses its temporally grounded knowledge to provide relevant and timely assistance.
 
 ### Website Context
 Website Context allows the Copilot to understand the content of websites. By using the [Pieces Web Extension](/extensions-plugins/web-extension) to add a website to your Copilot context, the system automatically extracts relevant content and integrates this information into the Copilot’s knowledge base.

--- a/docs/product-highlights-and-benefits/live-context.mdx
+++ b/docs/product-highlights-and-benefits/live-context.mdx
@@ -1,53 +1,53 @@
 ---
-title: Live Context
-description: Powered by our Workstream Pattern Engine, Live Context enables the world’s first Temporally Grounded Copilot that understands your unique workflow
+title: Long-Term Memory
+description: Powered by our Long-Term Memory Engine, Long-Term Memory enables the world’s first Temporally Grounded Copilot that understands your unique workflow
 ---
 
 import {MiniSpacer} from "/src/components/Spacers";
 import Video from "/src/components/Video";
 
-# Applying Live Context to your Copilot
+# Applying Long-Term Memory to your Copilot
 
-Since the original launch of Pieces for Developers, we’ve been laser-focused on developer productivity. We started by giving devs a place to store their most valuable snippets of code, then moved on to proactively saving and contextualizing them. Next, we built one of the first on-device LLM-powered AI copilots in the Pieces Copilot. Now, we’re taking our obsession with contextual developer productivity to the next level with the launch of Live Context within our copilot, making it the world’s first temporally grounded copilot.
+Since the original launch of Pieces for Developers, we’ve been laser-focused on developer productivity. We started by giving devs a place to store their most valuable snippets of code, then moved on to proactively saving and contextualizing them. Next, we built one of the first on-device LLM-powered AI copilots in the Pieces Copilot. Now, we’re taking our obsession with contextual developer productivity to the next level with the launch of Long-Term Memory within our copilot, making it the world’s first temporally grounded copilot.
 
 <Video type={'youtube'} src={'https://www.youtube.com/embed/aP8u95RTCGE?si=y4bhrmzG9KWsD1AS'}/>
 <MiniSpacer />
 
-We would like to introduce **Live Context** in Pieces for Developers, **powered by our Workstream Pattern Engine (WPE)**, which enables **the world’s first Temporally Grounded Copilot**.
+We would like to introduce **Long-Term Memory** in Pieces for Developers, **powered by our Long-Term Memory Engine (LTME)**, which enables **the world’s first Temporally Grounded Copilot**.
 
-[Live Context elevates the Pieces Copilot](https://code.pieces.app/blog/introducing-pieces-copilot-now-with-live-context), allowing it to understand your workflow and discuss how, where, and when you work. As with everything we do here at Pieces, this all happens entirely on-device and is available on [macOS](/installation-getting-started/macos), [Windows](/installation-getting-started/windows), and [Linux](/installation-getting-started/linux). We truly believe the Pieces Copilot+ will revolutionize how you cross off your to-dos.
+[Long-Term Memory elevates the Pieces Copilot](https://code.pieces.app/blog/introducing-pieces-copilot-now-with-live-context), allowing it to understand your workflow and discuss how, where, and when you work. As with everything we do here at Pieces, this all happens entirely on-device and is available on [macOS](/installation-getting-started/macos), [Windows](/installation-getting-started/windows), and [Linux](/installation-getting-started/linux). We truly believe the Pieces Copilot+ will revolutionize how you cross off your to-dos.
 
 By using context captured throughout your workflow, Pieces Copilot+ can provide hyper-aware assistance to guide you right back to where you left off. Ask it [novel AI prompts](https://pieces.app/blog/20-novel-ai-prompts-made-possible-only-by-pieces-copilot) like, “What was I working on an hour ago?” and let it help you get back into flow. Ask it, “How can I resolve the issue I got with Cocoa Pods in the terminal in IntelliJ?” or “What did Mack say I should test in the latest release?” and let Pieces Copilot surface the information that you know you have, but you can’t remember where.
 
 Pieces Copilot+ is now temporally grounded in exactly what you have been working on, which reduces the need for manual context input, enhances continuity in developer tasks, reduces context switching, and enables more natural, intuitive interactions with the Pieces Copilot.
 
-## The Workstream Pattern Engine
+## The Long-Term Memory Engine
 
-The Live Context in the Pieces Copilot comes from the Workstream Pattern Engine, which shadows your workflow on an operating system level. Whether you're on macOS, Windows, or Linux, your workflow will be locally captured, processed, and stored entirely on-device, where it is then available to be leveraged as Live Context within your current and future Copilot Chats. The Workstream Pattern Engine applies several on-device and real-time algorithms to this data to proactively capture the most important information as you go about your workday, wherever you are— your browser, your IDE, or your collaboration tools. Over time, the Workstream Pattern Engine learns more and more about your work and becomes increasingly helpful. It even takes context from your previous copilot chats to build on the knowledge you are capturing.
+The Long-Term Memory in the Pieces Copilot comes from the Long-Term Memory Engine, which shadows your workflow on an operating system level. Whether you're on macOS, Windows, or Linux, your workflow will be locally captured, processed, and stored entirely on-device, where it is then available to be leveraged as Long-Term Memory within your current and future Copilot Chats. The Long-Term Memory Engine applies several on-device and real-time algorithms to this data to proactively capture the most important information as you go about your workday, wherever you are— your browser, your IDE, or your collaboration tools. Over time, the Long-Term Memory Engine learns more and more about your work and becomes increasingly helpful. It even takes context from your previous copilot chats to build on the knowledge you are capturing.
 
-## Getting Started with Live Context
+## Getting Started with Long-Term Memory
 
-### Enabling/Disabling the WPE
+### Enabling/Disabling the LTME
 
-In order to use Live Context in your conversations with Pieces Copilot, you will need to enable the Workstream Pattern Engine. You can disable it at any time, but remember that the Copilot will not be able to use Live Context from when you had it disabled.
+In order to use Long-Term Memory in your conversations with Pieces Copilot, you will need to enable the Long-Term Memory Engine. You can disable it at any time, but remember that the Copilot will not be able to use Long-Term Memory from when you had it disabled.
 
-To enable or disable the engine, head to the Machine Learning section of the Settings page of the Pieces Desktop App. You’ll see a button to enable the Workstream Pattern Engine— hit it, and you’re good to go!
+To enable or disable the engine, head to the Machine Learning section of the Settings page of the Pieces Desktop App. You’ll see a button to enable the Long-Term Memory Engine— hit it, and you’re good to go!
 
-<Video type={'youtube'} src={'https://www.youtube.com/embed/-zdK1bX0W-Y?si=0MUQARStBgFzFpzW'} alt={'WPE Menu'}/>
+<Video type={'youtube'} src={'https://www.youtube.com/embed/-zdK1bX0W-Y?si=0MUQARStBgFzFpzW'} alt={'LTME Menu'}/>
 
-### Clearing Workstream Pattern Engine Data
+### Clearing Long-Term Memory Engine Data
 
-You also can clear Workstream Pattern Engine data at any time, from a specific time range or everything currently stored. Please note that once you take this action, the Pieces Copilot will not be able to apply Live Context from the selected range.
+You also can clear Long-Term Memory Engine data at any time, from a specific time range or everything currently stored. Please note that once you take this action, the Pieces Copilot will not be able to apply Long-Term Memory from the selected range.
 
-<Video type={'gif'} src={'/wpe/clear-data.gif'} alt={'WPE Clear Data'}/>
+<Video type={'gif'} src={'/wpe/clear-data.gif'} alt={'LTME Clear Data'}/>
 
-### Using Live Context
+### Using Long-Term Memory
 
-Once you've enabled the Workstream Pattern Engine, go about your usual work for a few minutes, and then head to the Copilot Chats view in the Pieces for Developers Desktop App and select “New Chat.” In the “Set Context” section, tap the option labeled “Live Context." Like before, you can leverage any of our available models, on-device or cloud, to engage with Live Context in the Pieces Copilot, and you can use it across your toolchain to carry on conversations in your favorite IDE and browser.
+Once you've enabled the Long-Term Memory Engine, go about your usual work for a few minutes, and then head to the Copilot Chats view in the Pieces for Developers Desktop App and select “New Chat.” In the “Set Context” section, tap the option labeled “Long-Term Memory." Like before, you can leverage any of our available models, on-device or cloud, to engage with Long-Term Memory in the Pieces Copilot, and you can use it across your toolchain to carry on conversations in your favorite IDE and browser.
 
 :::info
 
-The Workstream Pattern Engine must be turned on to use Live Context. We’ve made this super easy to do from wherever you’re getting started.
+The Long-Term Memory Engine must be turned on to use Long-Term Memory. We’ve made this super easy to do from wherever you’re getting started.
 
 :::
 
@@ -57,7 +57,7 @@ You can add additional context to further tailor the conversation if you’d lik
 
 :::info
 
-**For macOS users only**, you will need to update Pieces’ permissions in order to use Live Context.
+**For macOS users only**, you will need to update Pieces’ permissions in order to use Long-Term Memory.
 
 :::
 
@@ -71,10 +71,10 @@ You can also manually update this by adding and enabling Pieces OS in the follow
 #### Privacy & Security > Screen and System Audio Recording
 ![Screen and System Audio Recording Permissions](/wpe/screen-and-system-audio-permissions.png)
 
-## Live Context Use Cases
+## Long-Term Memory Use Cases
 
 :::tip
-We recommend clicking around your workflow between chats, websites, emails, code, etc., while the WPE is running before asking a question to get the most value out of it (i.e., data capture).
+We recommend clicking around your workflow between chats, websites, emails, code, etc., while the LTME is running before asking a question to get the most value out of it (i.e., data capture).
 :::
 
 ## Best Practices
@@ -113,10 +113,10 @@ Here are a few real prompts and use cases captured from the Pieces Team and Earl
 
 **Your workstream data is captured and stored locally on-device.** At no point will anyone, including the Pieces team, have access to this data unless you choose to share it with us.
 
-The Workstream Pattern Engine triangulates and leverages on-task and technical context across developer-specific tools you're actively using. The bulk of the processing that occurs within the Workstream Pattern Engine is filtering, which utilizes our on-device machine learning engines to ignore sensitive information and secrets. This enables the highest levels of performance, security, and privacy.
+The Long-Term Memory Engine triangulates and leverages on-task and technical context across developer-specific tools you're actively using. The bulk of the processing that occurs within the Long-Term Memory Engine is filtering, which utilizes our on-device machine learning engines to ignore sensitive information and secrets. This enables the highest levels of performance, security, and privacy.
 
-Lastly, for some advanced components within the Workstream Pattern Engine, blended processing is required to be set via user preferences, and you will need to leverage a cloud-powered Large Language Model as your copilot’s runtime.
+Lastly, for some advanced components within the Long-Term Memory Engine, blended processing is required to be set via user preferences, and you will need to leverage a cloud-powered Large Language Model as your copilot’s runtime.
 
 That said, you can leverage Local Large Language Models, but this may reduce the fidelity of output and requires a fairly new machine (2021 and newer) and ideally a dedicated GPU for this. You can read [this blog](https://code.pieces.app/blog/how-to-run-an-llm-locally-with-pieces) for more information about running local models on your machine.
 
-As always, we've built Pieces from the ground up to put you in control. With that, **the Workstream Pattern Engine may be paused and resumed at any time**.
+As always, we've built Pieces from the ground up to put you in control. With that, **the Long-Term Memory Engine may be paused and resumed at any time**.

--- a/docs/product-highlights-and-benefits/privacy-security-data.mdx
+++ b/docs/product-highlights-and-benefits/privacy-security-data.mdx
@@ -62,15 +62,15 @@ This table shows which models are available locally and which will use cloud com
 
 Our ML models are not trained continuously. They do not train on your data as you use the product!
 
-## Live Context
+## Long-Term Memory
 
-The Live Context feature in Pieces enhances the functionality of the Pieces Copilot by utilizing our proprietary Workstream Pattern Engine (WPE). This feature is designed with privacy and efficiency in mind, ensuring that all data processing and storage occur locally on your device.
+The Long-Term Memory feature in Pieces enhances the functionality of the Pieces Copilot by utilizing our proprietary Long-Term Memory Engine (LTME). This feature is designed with privacy and efficiency in mind, ensuring that all data processing and storage occur locally on your device.
 
-### How Live Context Works
+### How Long-Term Memory Works
 
-1. **On-Device Processing and Storage:** All WPE algorithms, processing, and storage take place directly on your device. This ensures that your data remains secure and private, without being transmitted over the internet unless necessary.
-2. **Querying Local Data:** When Live Context is enabled, and you ask a question to the Copilot, the system queries data aggregated from the WPE. This data is processed entirely on your device to find content that is relevant to your query.
-3. **Utilizing [Retrieval-Augmented Generation (RAG)](/build/glossary/terms/retrieval-augmented-generation) for Contextual Relevance:** The relevant content identified by the WPE is then used as context for the Copilot prompt.
+1. **On-Device Processing and Storage:** All LTME algorithms, processing, and storage take place directly on your device. This ensures that your data remains secure and private, without being transmitted over the internet unless necessary.
+2. **Querying Local Data:** When Long-Term Memory context is enabled, and you ask a question to the Copilot, the system queries data aggregated from the LTME. This data is processed entirely on your device to find content that is relevant to your query.
+3. **Utilizing [Retrieval-Augmented Generation (RAG)](/build/glossary/terms/retrieval-augmented-generation) for Contextual Relevance:** The relevant content identified by the LTME is then used as context for the Copilot prompt.
 4. **Interaction with Language Models (LLM):**
     - **Cloud LLM:** If you are using a cloud-based LLM, the data identified as relevant is sent to the cloud LLM for processing.
     - **Local LLM:** If you are using a local LLM, the data remains on your device, ensuring that all processing happens locally without any data leaving your device.
@@ -81,7 +81,7 @@ For users concerned about privacy, we strongly recommend using a Local LLM with 
 
 ### Performance Note
 
-Please note that results may vary depending on the selected LLM. Each model has its strengths and capabilities, which can influence the effectiveness of the Live Context feature.
+Please note that results may vary depending on the selected LLM. Each model has its strengths and capabilities, which can influence the effectiveness of the Long-Term Memory feature.
 
 ## Saving Code Snippets in the Cloud
 The Pieces cloud is entirely opt-in. Authentication is managed by our enterprise-ready authentication partners at Auth0 (now owned by Okta).

--- a/docs/resources/live-context.mdx
+++ b/docs/resources/live-context.mdx
@@ -1,11 +1,11 @@
 ---
-title: Live Context Reference
-description: Learn how to use Live Context in Pieces for Developers to enhance your workflow and productivity.
+title: Long-Term Memory Reference
+description: Learn how to use Long-Term Memory in Pieces for Developers to enhance your workflow and productivity.
 ---
 
-## Live Context Messaging:
-We would like to introduce Live Context in Pieces for Developers, powered by our Workstream Pattern Engine (WPE), which enables the world’s first Temporally Grounded Copilot.
-Live Context elevates the Pieces Copilot, allowing it to understand your workflow and discuss how, where, and when you work. As with everything we do here at Pieces, this all happens entirely on-device and is available on macOS, Windows, and Linux (coming soon). We truly believe the Pieces Copilot with Live Context will 10x your productivity. .
+## Long-Term Memory Messaging:
+We would like to introduce Long-Term Memory in Pieces for Developers, powered by our Long-Term Memory Engine (LTME), which enables the world’s first Temporally Grounded Copilot.
+Long-Term Memory elevates the Pieces Copilot, allowing it to understand your workflow and discuss how, where, and when you work. As with everything we do here at Pieces, this all happens entirely on-device and is available on macOS, Windows, and Linux (coming soon). We truly believe the Pieces Copilot with Long-Term Memory will 10x your productivity. .
 
 ## Core Benefits
 1. Reduce context switching and remove the need to search around your desktop to find a piece of information
@@ -15,20 +15,20 @@ Live Context elevates the Pieces Copilot, allowing it to understand your workflo
 ## Materials to Review and Share
 - [Introducing the Copilot+ Blog](https://code.pieces.app/blog/introducing-pieces-copilot-now-with-live-context)
 - [Introducing the Copilot+ Video](https://www.youtube.com/watch?v=aP8u95RTCGE)
-- [Live Context Documentation Page](https://docs.pieces.app/product-highlights-and-benefits/live-context)
+- [Long-Term Memory Documentation Page](https://docs.pieces.app/product-highlights-and-benefits/live-context)
 - [Tsavo's Excellent Demo and Discussion](https://x.com/i/broadcasts/1YpKkwQNZDmKj)
   - Demo Timestamps: 10:18-18:43
-- [Live Context Privacy and Security Documentation](https://docs.pieces.app/product-highlights-and-benefits/privacy-security-data#live-context)
+- [Long-Term Memory Privacy and Security Documentation](https://docs.pieces.app/product-highlights-and-benefits/privacy-security-data#live-context)
 - [The Pieces Team Magic Moments](https://www.youtube.com/watch?v=pEHdZyR83BU)
 - [Novel AI Prompts](https://pieces.app/blog/20-novel-ai-prompts-made-possible-only-by-pieces-copilot)
 
 ## Privacy and Security
-The Live Context feature in Pieces enhances the functionality of the Pieces Copilot by utilizing our proprietary Workstream Pattern Engine (WPE). This feature is designed with privacy and efficiency in mind, ensuring that all data processing and storage occur locally on your device.
+The Long-Term Memory feature in Pieces enhances the functionality of the Pieces Copilot by utilizing our proprietary Long-Term Memory Engine (LTME). This feature is designed with privacy and efficiency in mind, ensuring that all data processing and storage occur locally on your device.
 
-### How Live Context Works
-1. On-Device Processing and Storage: **All WPE algorithms, processing, and storage take place directly on your device. This ensures that your data remains secure and private, without being transmitted over the internet**.
-2. Querying Local Data: When Live Context is enabled, and you ask a question to the Copilot, the system queries data aggregated from the WPE. This data is processed entirely on your device to find content that is relevant to your query.
-3. Utilizing Retrieval-Augmented Generation (RAG) for Contextual Relevance: The relevant content identified by the WPE is then used as context for the Copilot prompt.
+### How Long-Term Memory Works
+1. On-Device Processing and Storage: **All LTME algorithms, processing, and storage take place directly on your device. This ensures that your data remains secure and private, without being transmitted over the internet**.
+2. Querying Local Data: When Long-Term Memory is enabled, and you ask a question to the Copilot, the system queries data aggregated from the LTME. This data is processed entirely on your device to find content that is relevant to your query.
+3. Utilizing Retrieval-Augmented Generation (RAG) for Contextual Relevance: The relevant content identified by the LTME is then used as context for the Copilot prompt.
 4. Interaction with Language Models (LLM):
     - Cloud LLM: If you are using a cloud-based LLM, the data identified as relevant is sent to the cloud LLM for processing.
     - Local LLM: If you are using a local LLM, the data remains on your device, ensuring that all processing happens locally without any data leaving your device.
@@ -37,7 +37,7 @@ The Live Context feature in Pieces enhances the functionality of the Pieces Copi
 For users concerned about privacy, we strongly recommend using a Local LLM with the Pieces Copilot. Options include Mistral, Phi-2, and Llama2, among others. Using a local LLM ensures that all data and processing remain on your device, providing an additional layer of security and privacy.
 
 ### Performance Note
-Please note that results may vary depending on the selected LLM. Each model has its strengths and capabilities, which can influence the effectiveness of the Live Context feature.
+Please note that results may vary depending on the selected LLM. Each model has its strengths and capabilities, which can influence the effectiveness of the Long-Term Memory feature.
 
 ## Use Cases
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -196,7 +196,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'doc',
               id: 'product-highlights-and-benefits/live-context',
-              label: 'Live Context',
+              label: 'Long-Term Memory',
             },
           ]
         },


### PR DESCRIPTION
Renames Live context to long term memory. Fixes #590 