### PR TITLE
announcing_v2_jetbrains_documentation

### DIFF
--- a/docs/extensions-plugins/jetbrains.mdx
+++ b/docs/extensions-plugins/jetbrains.mdx
@@ -9,12 +9,25 @@ import GridFlexRow from "/src/components/GridFlexRow";
 import CTAButton from "/src/components/CTAButton";
 import Video from "/src/components/Video";
 
+# Pieces for Developers JetBrains Plugin
+
+<img 
+  src="https://storage.googleapis.com/hashnode_product_documentation_assets/hashnode_general_assets/jetbrains_plugin_v2_live_banner.png" 
+  alt="JetBrains Plugin Banner" 
+  style={{ width: "100%", height: "auto", marginBottom: "20px" }} 
+/>
+
+We just launched brand new [documentation for the Pieces for JetBrains Plugin](https://beta.docs.pieces.app/products/extensions-plugins/jetbrains)!
+
+Check it out on our new documentation site and leave us some feedback.
+
 <CTAButton
-  href={pieces_app.links.extensions.jetbrains}
-  label={'Download the JetBrains Plugin'}
-  icon={'/assets/jetbrains_logo.png'}
+  href="https://beta.docs.pieces.app/products/extensions-plugins/jetbrains"
+  label={'Check out the JetBrains V2 Docs'}
   type={'secondary'}
 />
+
+## Getting Started
 
 <MiniSpacer />
 


### PR DESCRIPTION
Added a banner, links, new button and a CTA announcing the V2 JetBrains docs. Follows the same exact pattern as the current Sublime Text Docs that exists within the documentation repository. 