### PR TITLE
replacing_old_v2_sublime_text_link

### DIFF
--- a/docs/extensions-plugins/sublime.mdx
+++ b/docs/extensions-plugins/sublime.mdx
@@ -16,12 +16,12 @@ import { MiniSpacer } from "/src/components/Spacers";
   style={{ width: "100%", height: "auto", marginBottom: "20px" }} 
 />
 
-We just launched brand new [documentation for the Pieces for Sublime Text Plugin](https://beta.docs.pieces.app/getting-started/extensions-plugins/sublime-plugin)!
+We just launched brand new [documentation for the Pieces for Sublime Text Plugin](https://beta.docs.pieces.app/products/extensions-plugins/sublime)!
 
 Check it out on our new documentation site and leave us some feedback.
 
 <CTAButton
-  href="https://beta.docs.pieces.app/getting-started/extensions-plugins/sublime-plugin"
+  href="https://beta.docs.pieces.app/products/extensions-plugins/sublime"
   label={'Check out the Sublime V2 Docs'}
   type={'secondary'}
 />


### PR DESCRIPTION
replacing the out of date v2 sublime text documentation link with the current one