### PR TITLE
announce_v2_vs_code_docs

### DIFF
--- a/docs/extensions-plugins/vscode.mdx
+++ b/docs/extensions-plugins/vscode.mdx
@@ -9,6 +9,26 @@ import Video from "/src/components/Video";
 import GridFlexRow from "/src/components/GridFlexRow";
 import CTAButton from "/src/components/CTAButton";
 
+<img 
+  src="https://storage.googleapis.com/hashnode_product_documentation_assets/vs-code.png" 
+  alt="Visual Studio Code Extension Banner" 
+  style={{ width: "100%", height: "auto", marginBottom: "20px" }} 
+/>
+
+We just launched brand new [documentation for the Pieces for Visual Studio Code Extension!](https://beta.docs.pieces.app/products/extensions-plugins/visual-studio-code)
+
+Check it out on our new documentation site and leave us some feedback.
+
+<CTAButton
+  href="https://beta.docs.pieces.app/products/extensions-plugins/visual-studio-code"
+  label={'Check out the Visual Code Studio V2 Docs'}
+  type={'secondary'}
+/>
+
+## Getting Started
+
+Using the Pieces for Developers VS Code Extension in combination with the Pieces Desktop App makes saving and reusing code simple within your IDE.
+
 <CTAButton
   href={pieces_app.links.extensions.vscode}
   label={'Install the VS Code Extension'}
@@ -17,10 +37,6 @@ import CTAButton from "/src/components/CTAButton";
 />
 
 <MiniSpacer />
-
-Using the Pieces for Developers VS Code Extension in combination with the Pieces Desktop App makes saving and reusing code simple within your IDE.
-
-## Installing the Pieces for Developers VS Code Extension
 :::info
 
 In order to use the Pieces VS Code Extension, you must have <a target="blank" href="/installation-getting-started/what-am-i-installing">Pieces OS.</a> We also recommend downloading the Pieces for Developers Desktop App.


### PR DESCRIPTION
edited landing page to match convention of sublime and JB announcements, added header, added new links to redirect to new docs