### PR TITLE
Adding get pieces to the navbar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,6 +81,11 @@ const config: Config = {
       },
       items: [
         {
+          to: '/installation-getting-started/what-am-i-installing',
+          label: 'Get Pieces',
+          position: 'right',
+        },
+        {
           to: '/',
           label: 'Home',
           position: 'right',


### PR DESCRIPTION
This change adds a Get Pieces link to the navbar so from any page when learning about Pieces it's easier to get to the install page with one click.