### PR TITLE
remove_pos_pfd_exe_download_links

### DIFF
--- a/docs/installation-getting-started/pieces-os.mdx
+++ b/docs/installation-getting-started/pieces-os.mdx
@@ -69,12 +69,9 @@ Downloading Pieces OS by itself is not recommended, but is the right solution fo
 <details>
   <summary>Windows</summary>
 
-  If you aren't sure which of these you need, click "Download Pieces Suite Installer" above - it will install both applications and manage them as updates are released.
-
-  If this isn't your first rodeo, here is the list of downloadable files for windows:
+  Click the download link below to install PiecesOS on your Windows machine with the provided Appinstaller file: 
 
   - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller)
-  - [Pieces OS](/installation-getting-started/pieces-os) EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/os_server/windows-exe/download)
 </details>
 
 <MiniSpacer />

--- a/docs/installation-getting-started/windows.mdx
+++ b/docs/installation-getting-started/windows.mdx
@@ -83,8 +83,6 @@ If you've already installed the Pieces Desktop App, and it's having trouble conn
   If this isn't your first rodeo, here is the list of downloadable files for windows:
   - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller)
   - Pieces for Developers Desktop App Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/pieces_for_x.appinstaller)
-  - [Pieces OS](/installation-getting-started/pieces-os) EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/os_server/windows-exe/download)
-  - Pieces for Developers Desktop App EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/windows-exe/download)
 </details>
 
 


### PR DESCRIPTION
Temporarily removes POS and PFD .EXE file download links for Windows devices on the Desktop App > Windows page & PiecesOS page.

@mark-at-pieces @nolan-at-pieces 