### PR TITLE
reinstate_temp_removed_pos_pfd_exe_dl_links

### DIFF
--- a/docs/installation-getting-started/pieces-os.mdx
+++ b/docs/installation-getting-started/pieces-os.mdx
@@ -69,9 +69,10 @@ Downloading Pieces OS by itself is not recommended, but is the right solution fo
 <details>
   <summary>Windows</summary>
 
-  Click the download link below to install PiecesOS on your Windows machine with the provided Appinstaller file: 
+  Click the download link below to install PiecesOS on your Windows machine with the provided Appinstaller file, or download the standalone installer for Windows: 
 
   - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller)
+  - [PiecesOS](/installation-getting-started/pieces-os) .EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/os_server/windows-exe/download?download=true&product=DOCUMENTATION_WEBSITE)
 </details>
 
 <MiniSpacer />

--- a/docs/installation-getting-started/windows.mdx
+++ b/docs/installation-getting-started/windows.mdx
@@ -83,6 +83,8 @@ If you've already installed the Pieces Desktop App, and it's having trouble conn
   If this isn't your first rodeo, here is the list of downloadable files for windows:
   - [Pieces OS](/installation-getting-started/pieces-os) Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/os_server.appinstaller)
   - Pieces for Developers Desktop App Appinstaller (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/appinstaller/pieces_for_x.appinstaller)
+  - [PiecesOS](/installation-getting-started/pieces-os) .EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/os_server/windows-exe/download?download=true&product=DOCUMENTATION_WEBSITE)
+  - Pieces for Developers Desktop App .EXE (Standalone Windows) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/windows-exe/download?download=true&product=DOCUMENTATION_WEBSITE)
 </details>
 
 


### PR DESCRIPTION
Adds windows .exe download links for POS and PFD that were temporarily removed in a previous PR due to a bug that was resolved in the POS update to 11.1.1.