### PR TITLE
edit_arm_pos_pfd_dl_link_copy

### DIFF
--- a/docs/installation-getting-started/macos.mdx
+++ b/docs/installation-getting-started/macos.mdx
@@ -53,14 +53,14 @@ import DownloadLinkUpdater from "/src/components/DownloadLinkUpdater";
 ![Robots installing Pieces for Developers on macOS.](/assets/installation/robots_macos.png)
 
 <CTAButton
-  href={'https://builds.pieces.app/stages/production/macos_packaging/pkg/download'}
-  label={'Download Pieces Package (Intel)'}
+  href={'https://builds.pieces.app/stages/production/macos_packaging/pkg-arm64/download'}
+  label={'Download Pieces Package (ARM / M-Series / Apple Silicon)'}
   type={'secondary'}
 />
 <MiniSpacer />
 <CTAButton
-  href={'https://builds.pieces.app/stages/production/macos_packaging/pkg-arm64/download'}
-  label={'Download Pieces Package (Apple Silicon)'}
+  href={'https://builds.pieces.app/stages/production/macos_packaging/pkg/download'}
+  label={'Download Pieces Package (Intel)'}
   type={'secondary'}
 />
 
@@ -77,11 +77,11 @@ import DownloadLinkUpdater from "/src/components/DownloadLinkUpdater";
   If you have an Intel chip, select the Intel package above. Those with Apple M1 or M2 chips should select the "Apple Silicon" package.
 
   If this isn't your first rodeo, here is the list of downloadable files for macOS:
-  - [Pieces OS](/installation-getting-started/pieces-os) DMG (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg/download)
-  - Pieces for Developers Desktop App DMG (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/dmg/download)
-  - [Pieces OS](/installation-getting-started/pieces-os) DMG ARM64 (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg-arm64/download)
-  - Pieces for Developers Desktop App DMG ARM64 (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/dmg-arm64/download)
-
+  - [PiecesOS](/installation-getting-started/pieces-os) DMG (ARM / M-Series / Apple Silicon) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg-arm64/download)
+  - Pieces for Developers Desktop App DMG (ARM / M-Series / Apple Silicon) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/dmg-arm64/download)
+  - [PiecesOS](/installation-getting-started/pieces-os) DMG (Intel) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg/download)
+  - Pieces for Developers Desktop App DMG (Intel) | [Download Here](https://builds.pieces.app/stages/production/pieces_for_x/dmg/download)
+  
   Note: You can also install Pieces via Homebrew.
 
   1. Ensure you have [installed](https://docs.brew.sh/Installation) Homebrew in your system

--- a/docs/installation-getting-started/pieces-os.mdx
+++ b/docs/installation-getting-started/pieces-os.mdx
@@ -88,9 +88,9 @@ Downloading Pieces OS by itself is not recommended, but is the right solution fo
   If you have an Intel chip, select the Intel package above. Those with Apple M1 or M2 chips should select the "Apple Silicon" package.
 
   If this isn't your first rodeo, here is the list of downloadable files for macOS:
-  - [Pieces OS](/installation-getting-started/pieces-os) DMG (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg/download)
-  - [Pieces OS](/installation-getting-started/pieces-os) DMG ARM64 (Standalone Mac) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg-arm64/download)
-
+  - [PiecesOS](/installation-getting-started/pieces-os) DMG (ARM / M-Series / Apple Silicon) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg-arm64/download)
+  - [PiecesOS](/installation-getting-started/pieces-os) DMG (Intel) | [Download Here](https://builds.pieces.app/stages/production/os_server/dmg/download)
+  
   Note: You can also install Pieces via Homebrew.
 
   1. Ensure you have [installed](https://docs.brew.sh/Installation) Homebrew in your system


### PR DESCRIPTION
Specifies more clearly the ARM / M-Series / Apple Silicon (from just ARM) copy for POS and PFD download links on PiecesOS and Desktop App documentation pages to make it more evident for users to download the right files for their architecture.